### PR TITLE
#343-pause-message-staying-stuck-on-Screen

### DIFF
--- a/Assets/Scripts/Services/PauseService.cs
+++ b/Assets/Scripts/Services/PauseService.cs
@@ -32,7 +32,7 @@ namespace Assets.Scripts.Services
             }
         }
 
-        private void OnLevelWasLoaded(int level)
+        private void OnLevelWasLoaded()
         {
             if (this.IsPaused())
             {

--- a/Assets/Scripts/Services/PauseService.cs
+++ b/Assets/Scripts/Services/PauseService.cs
@@ -31,6 +31,14 @@ namespace Assets.Scripts.Services
                 OnUnPaused?.Invoke(this, EventArgs.Empty);
             }
         }
+
+        private void OnLevelWasLoaded(int level)
+        {
+            if (this.IsPaused())
+            {
+                this.Pause(false, true);
+            }
+        }
         
         private void LateUpdate()
         {


### PR DESCRIPTION
Fixed by unpausing whenever the level is loaded, per Lithrun's suggestion. Fix seems to work a expected in single player and multiplayer.