### PR TITLE
#367 kill dmg not clearing from the screen

### DIFF
--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -2827,9 +2827,9 @@ namespace Assets.Scripts
         [PunRPC]
         private void updateKillInfo(bool t1, string killer, bool t2, string victim, int dmg)
         {
-            GameObject killFeed = GameObject.Find("KillFeed");
-            GameObject newKillInfo = (GameObject) UnityEngine.Object.Instantiate(Resources.Load("UI/KillInfo"));
-            foreach (GameObject killInfo in killInfoGO)
+            var killFeed = GameObject.Find("KillFeed");
+            var newKillInfo = (GameObject) UnityEngine.Object.Instantiate(Resources.Load("UI/KillInfo"));
+            foreach (var killInfo in killInfoGO)
             {
                 if (killInfo != null)
                 {
@@ -2839,7 +2839,7 @@ namespace Assets.Scripts
 
             if (killInfoGO.Count > 4)
             {
-                var lastKillInfo = (GameObject) killInfoGO[0];
+                var lastKillInfo = killInfoGO[0];
                 if (lastKillInfo != null)
                 {
                     lastKillInfo.GetComponent<KillInfo>().Destroy();

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -2827,31 +2827,30 @@ namespace Assets.Scripts
         [PunRPC]
         private void updateKillInfo(bool t1, string killer, bool t2, string victim, int dmg)
         {
-            GameObject obj4;
-            GameObject obj2 = GameObject.Find("KillFeed");
-            GameObject obj3 = (GameObject) UnityEngine.Object.Instantiate(Resources.Load("UI/KillInfo"));
-            for (int i = 0; i < this.killInfoGO.Count; i++)
+            GameObject killFeed = GameObject.Find("KillFeed");
+            GameObject newKillInfo = (GameObject) UnityEngine.Object.Instantiate(Resources.Load("UI/KillInfo"));
+            foreach (GameObject killInfo in killInfoGO)
             {
-                obj4 = (GameObject) this.killInfoGO[i];
-                if (obj4 != null)
+                if (killInfo != null)
                 {
-                    obj4.GetComponent<KillInfo>().MoveOn();
+                    killInfo.GetComponent<KillInfo>().MoveOn();
                 }
-            }
-            if (this.killInfoGO.Count > 4)
-            {
-                obj4 = (GameObject) this.killInfoGO[0];
-                if (obj4 != null)
-                {
-                    obj4.GetComponent<KillInfo>().Destroy();
-                }
-                this.killInfoGO.RemoveAt(0);
             }
 
-            obj3.transform.parent = obj2.transform;
-            obj3.transform.position = new Vector3();
-            obj3.GetComponent<KillInfo>().Show(t1, killer, t2, victim, dmg);
-            this.killInfoGO.Add(obj3);
+            if (killInfoGO.Count > 4)
+            {
+                var lastKillInfo = (GameObject) killInfoGO[0];
+                if (lastKillInfo != null)
+                {
+                    lastKillInfo.GetComponent<KillInfo>().Destroy();
+                }
+                killInfoGO.RemoveAt(0);
+            }
+
+            newKillInfo.transform.parent = killFeed.transform;
+            newKillInfo.transform.position = new Vector3();
+            newKillInfo.GetComponent<KillInfo>().Show(t1, killer, t2, victim, dmg);
+            killInfoGO.Add(newKillInfo);
         }
 
         [PunRPC]

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -68,7 +68,7 @@ namespace Assets.Scripts
         [Obsolete("Only used for Cannons. Remove in Issue #75")]
         public bool isRestarting;
         public bool isUnloading;
-        private List<GameObject> killInfoGO = new List<GameObject>();
+        private readonly List<GameObject> killInfoGO = new List<GameObject>();
         [Obsolete("Legacy method of keeping track of custom level scripts, which we no longer support")]
         public List<string[]> levelCache;
         public static ExitGames.Client.Photon.Hashtable[] linkHash;

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -68,7 +68,7 @@ namespace Assets.Scripts
         [Obsolete("Only used for Cannons. Remove in Issue #75")]
         public bool isRestarting;
         public bool isUnloading;
-        private ArrayList killInfoGO = new ArrayList();
+        private List<GameObject> killInfoGO = new List<GameObject>();
         [Obsolete("Legacy method of keeping track of custom level scripts, which we no longer support")]
         public List<string[]> levelCache;
         public static ExitGames.Client.Photon.Hashtable[] linkHash;
@@ -1859,7 +1859,7 @@ namespace Assets.Scripts
             var propertiesToSet = hashtable;
             PhotonNetwork.player.SetCustomProperties(propertiesToSet);
             this.needChooseSide = true;
-            this.killInfoGO = new ArrayList();
+            this.killInfoGO = new List<GameObject>();
             this.name = LoginFengKAI.player.name;
             var hashtable3 = new ExitGames.Client.Photon.Hashtable
             {
@@ -2242,7 +2242,7 @@ namespace Assets.Scripts
             {
                 this.checkpoint = null;
                 this.myRespawnTime = 0f;
-                this.killInfoGO = new ArrayList();
+                this.killInfoGO = new List<GameObject>()
                 this.racingResult = new ArrayList();
                 this.isRestarting = true;
                 this.DestroyAllExistingCloths();

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -1859,7 +1859,7 @@ namespace Assets.Scripts
             var propertiesToSet = hashtable;
             PhotonNetwork.player.SetCustomProperties(propertiesToSet);
             this.needChooseSide = true;
-            this.killInfoGO = new List<GameObject>();
+            this.ClearKillInfo();
             this.name = LoginFengKAI.player.name;
             var hashtable3 = new ExitGames.Client.Photon.Hashtable
             {
@@ -2242,7 +2242,7 @@ namespace Assets.Scripts
             {
                 this.checkpoint = null;
                 this.myRespawnTime = 0f;
-                this.killInfoGO = new List<GameObject>()
+                this.ClearKillInfo();
                 this.racingResult = new ArrayList();
                 this.isRestarting = true;
                 this.DestroyAllExistingCloths();
@@ -2851,6 +2851,15 @@ namespace Assets.Scripts
             newKillInfo.transform.position = new Vector3();
             newKillInfo.GetComponent<KillInfo>().Show(t1, killer, t2, victim, dmg);
             killInfoGO.Add(newKillInfo);
+        }
+
+        private void ClearKillInfo()
+        {
+            foreach (var killInfo in killInfoGO)
+            {
+                Destroy(killInfo);
+            }
+            killInfoGO.Clear();
         }
 
         [PunRPC]

--- a/Assets/Scripts/Services/UiService.cs
+++ b/Assets/Scripts/Services/UiService.cs
@@ -49,6 +49,8 @@ namespace Assets.Scripts.Services
                 = labels.TopRight.text
                 = labels.Center.text
                     = string.Empty;
+
+            Ui.HUD.ClearDamage();
         }
 
         public void SetMessage(LabelPosition label, string message)

--- a/Assets/Scripts/UI/InGame/HUD/HUD.cs
+++ b/Assets/Scripts/UI/InGame/HUD/HUD.cs
@@ -21,10 +21,20 @@ namespace Assets.Scripts.UI.InGame.HUD
             ShowDamage();
         }
 
+        public void ClearDamage()
+        {
+            var damageLabels = Damage.GetComponentsInChildren<Text>();
+            foreach (var label in damageLabels)
+            {
+                label.text = string.Empty;
+            }
+        }
+
         private void ShowDamage()
         {
             Damage.GetComponent<Animator>().SetTrigger("ShowDamage");
         }
+
         private int ScaleDamageText(int damage)
         {
             var baseFontSize = 150;


### PR DESCRIPTION
Applied fix by resetting kill info and damage UI elements upon level load. Change seems to work as expected. Closes #367.