### PR TITLE
#390-Female-Titan-doesn't-spawn-in-Alpha-0.2's-Forest-Annie-Gamemode

### DIFF
--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -153,7 +153,6 @@ namespace Assets.Scripts
             Level = PhotonNetwork.room.GetLevel();
             var gamemodeSettings = PhotonNetwork.room.GetGamemodeSetting(Level);
             SetGamemode(gamemodeSettings);
-            Service.Settings.SetGamemodeType(gamemodeSettings.GamemodeType);
         }
 
         private void cache()


### PR DESCRIPTION
One line change which removes an uneccessary setting of Gamemode since it's already been set in FengGameManagerMKII's 'SetGamemode'. This uneccessary set reset the game mode settings to default; therefore no Annie. Closes #390.