### PR TITLE
#349 death scoreboard inconsistencies

### DIFF
--- a/Assets/Scripts/Characters/AHSSShotGunCollider.cs
+++ b/Assets/Scripts/Characters/AHSSShotGunCollider.cs
@@ -88,7 +88,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         var mindlessTitan = item.transform.root.GetComponent<MindlessTitan>();
                         if (PhotonNetwork.isMasterClient)
                         {
-                            mindlessTitan.OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, damage);
+                            mindlessTitan.OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, damage, new PhotonMessageInfo());
                         }
                         else
                         {
@@ -128,7 +128,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                             {
                                 GameObject.Find("MainCamera").GetComponent<IN_GAME_MAIN_CAMERA>().startSnapShot2(item.transform.position, num7, null, 0.02f);
                             }
-                            item.transform.root.GetComponent<FemaleTitan>().OnNapeHitRpc2(base.transform.root.gameObject.GetPhotonView().viewID, num7, new PhotonMessageInfo());
+                            item.transform.root.GetComponent<FemaleTitan>().OnNapeHitRpc(base.transform.root.gameObject.GetPhotonView().viewID, num7, new PhotonMessageInfo());
                         }
                     }
                     else if ((item.transform.root.GetComponent<ColossalTitan>() != null) && !item.transform.root.GetComponent<ColossalTitan>().hasDie)
@@ -140,7 +140,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         {
                             GameObject.Find("MainCamera").GetComponent<IN_GAME_MAIN_CAMERA>().startSnapShot2(item.transform.position, num8, null, 0.02f);
                         }
-                        item.transform.root.GetComponent<ColossalTitan>().OnNapeHitRpc2(transform.root.gameObject.GetPhotonView().viewID, num8, new PhotonMessageInfo());
+                        item.transform.root.GetComponent<ColossalTitan>().OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, num8, new PhotonMessageInfo());
                     }
                     this.showCriticalHitFX(other.gameObject.transform.position);
                 }

--- a/Assets/Scripts/Characters/AHSSShotGunCollider.cs
+++ b/Assets/Scripts/Characters/AHSSShotGunCollider.cs
@@ -92,7 +92,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         }
                         else
                         {
-                            mindlessTitan.photonView.RPC(nameof(mindlessTitan.OnNapeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
+                            mindlessTitan.photonView.RPC(nameof(MindlessTitan.OnNapeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
                         }
                     }
                     else if (!PhotonNetwork.isMasterClient)
@@ -178,7 +178,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         }
                         else
                         {
-                            mindlessTitan.photonView.RPC(nameof(mindlessTitan.OnEyeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
+                            mindlessTitan.photonView.RPC(nameof(MindlessTitan.OnEyeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
                         }
                         this.showCriticalHitFX(other.gameObject.transform.position);
                     }

--- a/Assets/Scripts/Characters/AHSSShotGunCollider.cs
+++ b/Assets/Scripts/Characters/AHSSShotGunCollider.cs
@@ -92,7 +92,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         }
                         else
                         {
-                            mindlessTitan.photonView.RPC("OnNapeHitRpc", mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
+                            mindlessTitan.photonView.RPC(nameof(mindlessTitan.OnNapeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
                         }
                     }
                     else if (!PhotonNetwork.isMasterClient)
@@ -178,7 +178,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         }
                         else
                         {
-                            mindlessTitan.photonView.RPC("OnEyeHitRpc", mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
+                            mindlessTitan.photonView.RPC(nameof(mindlessTitan.OnEyeHitRpc), mindlessTitan.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
                         }
                         this.showCriticalHitFX(other.gameObject.transform.position);
                     }

--- a/Assets/Scripts/Characters/AHSSShotGunCollider.cs
+++ b/Assets/Scripts/Characters/AHSSShotGunCollider.cs
@@ -88,7 +88,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         var mindlessTitan = item.transform.root.GetComponent<MindlessTitan>();
                         if (PhotonNetwork.isMasterClient)
                         {
-                            mindlessTitan.OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, damage, new PhotonMessageInfo());
+                            mindlessTitan.OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, damage);
                         }
                         else
                         {
@@ -128,7 +128,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                             {
                                 GameObject.Find("MainCamera").GetComponent<IN_GAME_MAIN_CAMERA>().startSnapShot2(item.transform.position, num7, null, 0.02f);
                             }
-                            item.transform.root.GetComponent<FemaleTitan>().OnNapeHitRpc(base.transform.root.gameObject.GetPhotonView().viewID, num7, new PhotonMessageInfo());
+                            item.transform.root.GetComponent<FemaleTitan>().OnNapeHitRpc(base.transform.root.gameObject.GetPhotonView().viewID, num7);
                         }
                     }
                     else if ((item.transform.root.GetComponent<ColossalTitan>() != null) && !item.transform.root.GetComponent<ColossalTitan>().hasDie)
@@ -140,7 +140,7 @@ public class AHSSShotGunCollider : MonoBehaviour
                         {
                             GameObject.Find("MainCamera").GetComponent<IN_GAME_MAIN_CAMERA>().startSnapShot2(item.transform.position, num8, null, 0.02f);
                         }
-                        item.transform.root.GetComponent<ColossalTitan>().OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, num8, new PhotonMessageInfo());
+                        item.transform.root.GetComponent<ColossalTitan>().OnNapeHitRpc(transform.root.gameObject.GetPhotonView().viewID, num8);
                     }
                     this.showCriticalHitFX(other.gameObject.transform.position);
                 }

--- a/Assets/Scripts/Characters/EnemyCheckCollider.cs
+++ b/Assets/Scripts/Characters/EnemyCheckCollider.cs
@@ -72,14 +72,14 @@ public class EnemyCheckCollider : Photon.MonoBehaviour
                                 myOwnerViewID = base.transform.root.gameObject.GetComponent<EnemyfxIDcontainer>().myOwnerViewID;
                                 titanName = base.transform.root.gameObject.GetComponent<EnemyfxIDcontainer>().titanName;
                             }
-                            object[] objArray2 = new object[5];
                             Vector3 vector5 = component.transform.root.position - base.transform.position;
-                            objArray2[0] = (Vector3) (((vector5.normalized * b) * 1000f) + (Vector3.up * 50f));
-                            objArray2[1] = this.isThisBite;
-                            objArray2[2] = myOwnerViewID;
-                            objArray2[3] = titanName;
-                            objArray2[4] = true;
-                            component.transform.root.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, objArray2);
+                            object[] netDieParameters = new object[5];
+                            netDieParameters[0] = (Vector3) (((vector5.normalized * b) * 1000f) + (Vector3.up * 50f));
+                            netDieParameters[1] = this.isThisBite;
+                            netDieParameters[2] = myOwnerViewID;
+                            netDieParameters[3] = titanName;
+                            netDieParameters[4] = true;
+                            component.transform.root.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, netDieParameters);
                         }
                     }
                 }

--- a/Assets/Scripts/Characters/EnemyCheckCollider.cs
+++ b/Assets/Scripts/Characters/EnemyCheckCollider.cs
@@ -79,7 +79,7 @@ public class EnemyCheckCollider : Photon.MonoBehaviour
                             netDieParameters[2] = myOwnerViewID;
                             netDieParameters[3] = titanName;
                             netDieParameters[4] = true;
-                            component.transform.root.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, netDieParameters);
+                            component.transform.root.GetComponent<Hero>().photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, netDieParameters);
                         }
                     }
                 }

--- a/Assets/Scripts/Characters/Horse/Horse.cs
+++ b/Assets/Scripts/Characters/Horse/Horse.cs
@@ -70,7 +70,7 @@ public sealed class Horse : PhotonView
     {
         animation.CrossFade(aniName, time);
         if (PhotonNetwork.connected && photonView.isMine)
-            photonView.RPC("netCrossFade", PhotonTargets.Others, aniName, time);
+            photonView.RPC(nameof(netCrossFade), PhotonTargets.Others, aniName, time);
     }
 
     private void DisableDust()
@@ -78,7 +78,7 @@ public sealed class Horse : PhotonView
         if (dustParticles.enableEmission)
         {
             dustParticles.enableEmission = false;
-            photonView.RPC("setDust", PhotonTargets.Others, false);
+            photonView.RPC(nameof(setDust), PhotonTargets.Others, false);
         }
     }
 
@@ -87,7 +87,7 @@ public sealed class Horse : PhotonView
         if (!dustParticles.enableEmission)
         {
             dustParticles.enableEmission = true;
-            photonView.RPC("setDust", PhotonTargets.Others, true);
+            photonView.RPC(nameof(setDust), PhotonTargets.Others, true);
         }
     }
 

--- a/Assets/Scripts/Characters/Human/Bullet.cs
+++ b/Assets/Scripts/Characters/Human/Bullet.cs
@@ -111,7 +111,7 @@ public class Bullet : Photon.MonoBehaviour
                 if (hit.collider.transform.gameObject.layer == LayerMask.NameToLayer("EnemyBox"))
                 {
                     object[] parameters = new object[] { hit.collider.transform.root.gameObject.GetPhotonView().viewID };
-                    base.photonView.RPC("tieMeToOBJ", PhotonTargets.Others, parameters);
+                    base.photonView.RPC(nameof(tieMeToOBJ), PhotonTargets.Others, parameters);
                     this.master.GetComponent<Hero>().lastHook = hit.collider.transform.root;
                     base.transform.parent = hit.collider.transform;
                 }
@@ -122,7 +122,7 @@ public class Bullet : Photon.MonoBehaviour
                 else if (((hit.collider.transform.gameObject.layer == LayerMask.NameToLayer("NetworkObject")) && (hit.collider.transform.gameObject.tag == "Player")) && !this.leviMode)
                 {
                     object[] objArray3 = new object[] { hit.collider.transform.root.gameObject.GetPhotonView().viewID };
-                    base.photonView.RPC("tieMeToOBJ", PhotonTargets.Others, objArray3);
+                    base.photonView.RPC(nameof(tieMeToOBJ), PhotonTargets.Others, objArray3);
                     this.master.GetComponent<Hero>().hookToHuman(hit.collider.transform.root.gameObject, base.transform.position);
                     base.transform.parent = hit.collider.transform;
                     this.master.GetComponent<Hero>().lastHook = null;
@@ -143,9 +143,9 @@ public class Bullet : Photon.MonoBehaviour
                     {
                         this.phase = 1;
                         object[] objArray4 = new object[] { 1 };
-                        base.photonView.RPC("setPhase", PhotonTargets.Others, objArray4);
+                        base.photonView.RPC(nameof(setPhase), PhotonTargets.Others, objArray4);
                         object[] objArray5 = new object[] { base.transform.position };
-                        base.photonView.RPC("tieMeTo", PhotonTargets.Others, objArray5);
+                        base.photonView.RPC(nameof(tieMeTo), PhotonTargets.Others, objArray5);
                         if (this.leviMode)
                         {
                             this.getSpiral(this.master.transform.position, this.master.transform.rotation.eulerAngles);
@@ -162,7 +162,7 @@ public class Bullet : Photon.MonoBehaviour
                 {
                     this.phase = 4;
                     object[] objArray6 = new object[] { 4 };
-                    base.photonView.RPC("setPhase", PhotonTargets.Others, objArray6);
+                    base.photonView.RPC(nameof(setPhase), PhotonTargets.Others, objArray6);
                 }
             }
         }
@@ -251,9 +251,9 @@ public class Bullet : Photon.MonoBehaviour
             if (base.photonView.isMine)
             {
                 object[] parameters = new object[] { hero.GetComponent<Hero>().photonView.viewID, launcher_ref };
-                base.photonView.RPC("myMasterIs", PhotonTargets.Others, parameters);
+                base.photonView.RPC(nameof(myMasterIs), PhotonTargets.Others, parameters);
                 object[] objArray2 = new object[] { v, this.velocity2, this.left };
-                base.photonView.RPC("setVelocityAndLeft", PhotonTargets.Others, objArray2);
+                base.photonView.RPC(nameof(setVelocityAndLeft), PhotonTargets.Others, objArray2);
             }
             base.transform.position = this.myRef.transform.position;
             base.transform.rotation = Quaternion.LookRotation(v.normalized);

--- a/Assets/Scripts/Characters/Human/Hero.cs
+++ b/Assets/Scripts/Characters/Human/Hero.cs
@@ -914,6 +914,11 @@ public class Hero : Human
             Transform transform = base.transform.Find("audio_die");
             transform.parent = null;
             transform.GetComponent<AudioSource>().Play();
+
+            var propertiesToSet = new ExitGames.Client.Photon.Hashtable();
+            propertiesToSet.Add(PhotonPlayerProperty.deaths, RCextensions.returnIntFromObject(PhotonNetwork.player.CustomProperties[PhotonPlayerProperty.deaths]) + 1);
+            photonView.owner.SetCustomProperties(propertiesToSet);
+
             if (PlayerPrefs.HasKey("EnableSS") && (PlayerPrefs.GetInt("EnableSS") == 1))
             {
                 GameObject.Find("MainCamera").GetComponent<IN_GAME_MAIN_CAMERA>().startSnapShot2(base.transform.position, 0, null, 0.02f);

--- a/Assets/Scripts/Characters/Human/Hero.cs
+++ b/Assets/Scripts/Characters/Human/Hero.cs
@@ -916,7 +916,7 @@ public class Hero : Human
             transform.GetComponent<AudioSource>().Play();
 
             var propertiesToSet = new ExitGames.Client.Photon.Hashtable();
-            propertiesToSet.Add(PhotonPlayerProperty.deaths, RCextensions.returnIntFromObject(PhotonNetwork.player.CustomProperties[PhotonPlayerProperty.deaths]) + 1);
+            propertiesToSet.Add(PhotonPlayerProperty.deaths, (int)PhotonNetwork.player.CustomProperties[PhotonPlayerProperty.deaths] + 1);
             photonView.owner.SetCustomProperties(propertiesToSet);
 
             if (PlayerPrefs.HasKey("EnableSS") && (PlayerPrefs.GetInt("EnableSS") == 1))

--- a/Assets/Scripts/Characters/Human/TriggerColliderWeapon.cs
+++ b/Assets/Scripts/Characters/Human/TriggerColliderWeapon.cs
@@ -33,15 +33,17 @@ public class TriggerColliderWeapon : MonoBehaviour
         currentHits.Clear();
     }
 
-    private void HeroHit(Hero hero, HitBox hitbox, float distance)
+    private void HeroHit(Hero hitHero, HitBox hitbox, float distance)
     {
-        if (hero.myTeam != myTeam && !hero.isInvincible() && hero.HasDied() && !hero.isGrabbed)
+        Service.Player.HeroHit(new HeroHitEvent(hitHero, hero));
+        if (hitHero.myTeam != myTeam && !hitHero.isInvincible() && hitHero.HasDied() && !hitHero.isGrabbed)
         {
             // I honestly don't have a clue as to what this does
             float b = Mathf.Min(1f, 1f - (distance * 0.05f));
 
-            hero.markDie();
-            hero.photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, new object[]
+            Service.Player.HeroKill(new HeroKillEvent(hitHero, hero));
+            hitHero.markDie();
+            hitHero.photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, new object[]
             {
                 ((hitbox.transform.root.position - transform.position.normalized * b) * 1000f) + (Vector3.up * 50f),
                 false,
@@ -80,8 +82,6 @@ public class TriggerColliderWeapon : MonoBehaviour
                 {
                     if (hitbox.transform.root != null && hitbox.transform.root.TryGetComponent(out Hero attackedHero))
                     {
-                        Service.Player.HeroHit(new HeroKillEvent(attackedHero, hero));
-
                         HeroHit(attackedHero, hitbox, Vector3.Distance(collider.gameObject.transform.position, transform.position));
                     }
                 }

--- a/Assets/Scripts/Characters/Human/TriggerColliderWeapon.cs
+++ b/Assets/Scripts/Characters/Human/TriggerColliderWeapon.cs
@@ -99,7 +99,7 @@ public class TriggerColliderWeapon : MonoBehaviour
                     Service.Player.TitanDamaged(new TitanDamagedEvent(titanBase, hero, damage));
                     Service.Player.TitanHit(new TitanHitEvent(titanBase, BodyPart.Nape, hero, RightHand));
 
-                    titanBase.photonView.RPC(nameof(TitanBase.OnNapeHitRpc2), titanBase.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
+                    titanBase.photonView.RPC(nameof(TitanBase.OnNapeHitRpc), titanBase.photonView.owner, transform.root.gameObject.GetPhotonView().viewID, damage);
                 }
                 break;
             case "titaneye":

--- a/Assets/Scripts/Characters/Titan/Attacks/Attack.cs
+++ b/Assets/Scripts/Characters/Titan/Attacks/Attack.cs
@@ -119,10 +119,24 @@ namespace Assets.Scripts.Characters.Titan.Attacks
             if (!Titan.photonView.isMine) return;
             if (entity is Hero hero)
             {
-                var position = Titan.Body.Chest.position;
                 hero.markDie();
-                object[] objArray3 = { (Vector3) ((entity.transform.position - position) * 15f * Titan.Size), false, Titan.photonView.viewID, Titan.name, true };
-                hero.photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, objArray3);
+                var knockbackVector = ((hero.transform.position - Titan.Body.Chest.position) * 15f * Titan.Size);
+
+                if (PhotonNetwork.offlineMode)
+                {
+                    hero.die(knockbackVector, (this is BiteAttack));
+                }
+                else
+                {
+                    object[] netDieParameters = new object[5];
+                    netDieParameters[0] = knockbackVector;
+                    netDieParameters[1] = (this is BiteAttack);
+                    netDieParameters[2] = Titan.photonView.viewID;
+                    netDieParameters[3] = Titan.name;
+                    netDieParameters[4] = true;
+
+                    hero.photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, netDieParameters);
+                }
             }
             else
             {

--- a/Assets/Scripts/Characters/Titan/Attacks/Attack.cs
+++ b/Assets/Scripts/Characters/Titan/Attacks/Attack.cs
@@ -131,7 +131,7 @@ namespace Assets.Scripts.Characters.Titan.Attacks
                     object[] netDieParameters = new object[5];
                     netDieParameters[0] = knockbackVector;
                     netDieParameters[1] = (this is BiteAttack);
-                    netDieParameters[2] = Titan.photonView.viewID;
+                    netDieParameters[2] = Titan is PlayerTitan ? Titan.photonView.viewID : -1;
                     netDieParameters[3] = Titan.name;
                     netDieParameters[4] = true;
 

--- a/Assets/Scripts/Characters/Titan/Attacks/GrabAttack.cs
+++ b/Assets/Scripts/Characters/Titan/Attacks/GrabAttack.cs
@@ -182,9 +182,10 @@ namespace Assets.Scripts.Characters.Titan.Attacks
                     : Titan.Body.HandRight;
 
                 var grabTarget = checkIfHitHand(hand, Titan.Size);
-                if (grabTarget != null)
+                if (grabTarget != null && grabTarget.GetComponent<Hero>() != null)
                 {
-                    EatSet(grabTarget);
+                    var hero = grabTarget.GetComponent<Hero>();
+                    EatSet(hero);
                     GrabbedTarget = grabTarget;
                 }
             }
@@ -198,24 +199,24 @@ namespace Assets.Scripts.Characters.Titan.Attacks
             }
         }
 
-        private void EatSet(GameObject grabTarget)
+        private void EatSet(Hero grabTarget)
         {
             var isLeftHand = Hand == BodyPart.HandLeft;
-            if (!Titan.photonView.isMine || !grabTarget.GetComponent<Hero>().isGrabbed)
+            if (!Titan.photonView.isMine || grabTarget.isGrabbed)
             {
                 Titan.Grab(isLeftHand);
                 if (Titan.photonView.isMine)
                 {
                     Titan.photonView.RPC("Grab", PhotonTargets.Others, isLeftHand);
                     var parameters = new object[] { "grabbed" };
-                    grabTarget.GetPhotonView().RPC("netPlayAnimation", PhotonTargets.All, parameters);
+                    grabTarget.photonView.RPC("netPlayAnimation", PhotonTargets.All, parameters);
                     var objArray2 = new object[] { Titan.photonView.viewID, isLeftHand };
-                    grabTarget.GetPhotonView().RPC("netGrabbed", PhotonTargets.All, objArray2);
+                    grabTarget.photonView.RPC("netGrabbed", PhotonTargets.All, objArray2);
                 }
                 else
                 {
-                    grabTarget.GetComponent<Hero>().grabbed(Titan.gameObject, isLeftHand);
-                    grabTarget.GetComponent<Hero>().GetComponent<Animation>().Play("grabbed");
+                    grabTarget.grabbed(Titan.gameObject, isLeftHand);
+                    grabTarget.GetComponent<Animation>().Play("grabbed");
                 }
             }
         }

--- a/Assets/Scripts/Characters/Titan/Attacks/JumpAttack.cs
+++ b/Assets/Scripts/Characters/Titan/Attacks/JumpAttack.cs
@@ -188,7 +188,7 @@ namespace Assets.Scripts.Characters.Titan.Attacks
                     {
                         hero.markDie();
                         object[] objArray8 = { (hero.transform.position - vector13) * 15f * Titan.Size, true, Titan.photonView.viewID, Titan.name, true };
-                        hero.photonView.RPC("netDie", PhotonTargets.All, objArray8);
+                        hero.photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, objArray8);
                     }
 
                     AttackAnimation = AnimationFall;

--- a/Assets/Scripts/Characters/Titan/Behavior/RandomAttackBehavior.cs
+++ b/Assets/Scripts/Characters/Titan/Behavior/RandomAttackBehavior.cs
@@ -12,7 +12,7 @@ namespace Assets.Scripts.Characters.Titan.Behavior
             //    nextUpdate = Mathf.FloorToInt(Time.time) + 0.1f;
             //    if (Random.Range(0, 100f) > 98.5f)
             //    {
-            //        Titan.ChangeState(TitanState.Attacking);
+            //        Titan.SetState(TitanState.Attacking);
             //        Titan.CurrentAttack = Titan.Attacks[Random.Range(0, Titan.Attacks.Length)];
             //        return true;
             //    }

--- a/Assets/Scripts/Characters/Titan/Behavior/RushBehavior.cs
+++ b/Assets/Scripts/Characters/Titan/Behavior/RushBehavior.cs
@@ -53,7 +53,7 @@ namespace Assets.Scripts.Characters.Titan.Behavior
 
         protected override bool OnChase()
         {
-            Titan.ChangeState(TitanState.Wandering);
+            Titan.SetState(TitanState.Wandering);
             return true;
         }
 

--- a/Assets/Scripts/Characters/Titan/Behavior/WaveBehavior.cs
+++ b/Assets/Scripts/Characters/Titan/Behavior/WaveBehavior.cs
@@ -38,7 +38,7 @@ namespace Assets.Scripts.Characters.Titan.Behavior
         {
             if (Titan.Target != null)
             {
-                Titan.ChangeState(TitanState.Chase);
+                Titan.SetState(TitanState.Chase);
                 return true;
             }
             return false;

--- a/Assets/Scripts/Characters/Titan/ColossalTitan.cs
+++ b/Assets/Scripts/Characters/Titan/ColossalTitan.cs
@@ -143,7 +143,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { aniName, time };
-                base.photonView.RPC("netCrossFade", PhotonTargets.Others, parameters);
+                base.photonView.RPC(nameof(netCrossFade), PhotonTargets.Others, parameters);
             }
         }
 
@@ -196,7 +196,7 @@ namespace Assets.Scripts.Characters.Titan
                 {
                     hitHero.GetComponent<Hero>().markDie();
                     object[] parameters = new object[] { (Vector3) (((hitHero.transform.position - position) * 15f) * 4f), false, -1, "Colossal Titan", true };
-                    hitHero.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, parameters);
+                    hitHero.GetComponent<Hero>().photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, parameters);
                 }
             }
         }
@@ -249,7 +249,7 @@ namespace Assets.Scripts.Characters.Titan
         {
             if (PhotonNetwork.isMasterClient && (((int) FengGameManagerMKII.settings[1]) == 1))
             {
-                base.photonView.RPC("loadskinRPC", PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x43] });
+                base.photonView.RPC(nameof(loadskinRPC), PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x43] });
             }
         }
 
@@ -366,7 +366,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { aniName };
-                base.photonView.RPC("netPlayAnimation", PhotonTargets.Others, parameters);
+                base.photonView.RPC(nameof(netPlayAnimation), PhotonTargets.Others, parameters);
             }
         }
 
@@ -377,7 +377,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { aniName, normalizedTime };
-                base.photonView.RPC("netPlayAnimationAt", PhotonTargets.Others, parameters);
+                base.photonView.RPC(nameof(netPlayAnimationAt), PhotonTargets.Others, parameters);
             }
         }
 
@@ -387,7 +387,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { sndname };
-                base.photonView.RPC("playsoundRPC", PhotonTargets.Others, parameters);
+                base.photonView.RPC(nameof(playsoundRPC), PhotonTargets.Others, parameters);
             }
         }
 
@@ -442,7 +442,7 @@ namespace Assets.Scripts.Characters.Titan
             if (base.photonView.isMine)
             {
                 //this.size = GameSettings.Titan.Colossal.Size.Value;
-                base.photonView.RPC("setSize", PhotonTargets.AllBuffered, new object[] { this.size });
+                base.photonView.RPC(nameof(setSize), PhotonTargets.AllBuffered, new object[] { this.size });
                 this.lagMax = 150f + (this.size * 3f);
                 this.healthTime = 0f;
                 this.maxHealth = Health;
@@ -452,7 +452,7 @@ namespace Assets.Scripts.Characters.Titan
                 }
                 if (this.Health > 0)
                 {
-                    base.photonView.RPC("labelRPC", PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
+                    base.photonView.RPC(nameof(labelRPC), PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
                 }
                 this.loadskin();
             }
@@ -580,7 +580,7 @@ namespace Assets.Scripts.Characters.Titan
                     }
                     if (this.maxHealth > 0f)
                     {
-                        base.photonView.RPC("labelRPC", PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
+                        base.photonView.RPC(nameof(labelRPC), PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
                     }
                     this.neckSteam();
 
@@ -589,7 +589,7 @@ namespace Assets.Scripts.Characters.Titan
                         this.Health = 0;
                         if (!this.hasDie)
                         {
-                            base.photonView.RPC("netDie", PhotonTargets.OthersBuffered, new object[0]);
+                            base.photonView.RPC(nameof(netDie), PhotonTargets.OthersBuffered, new object[0]);
                             this.netDie();
                             manager.titanGetKill(view.owner, damage, base.name);
                         }
@@ -598,7 +598,7 @@ namespace Assets.Scripts.Characters.Titan
                     {
                         manager.sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Colossal Titan's neck", damage);
                         object[] parameters = new object[] { damage };
-                        manager.photonView.RPC("netShowDamage", view.owner, parameters);
+                        manager.photonView.RPC(nameof(FengGameManagerMKII.netShowDamage), view.owner, parameters);
                     }
                     this.healthTime = 0.2f;
                 }

--- a/Assets/Scripts/Characters/Titan/ColossalTitan.cs
+++ b/Assets/Scripts/Characters/Titan/ColossalTitan.cs
@@ -565,7 +565,7 @@ namespace Assets.Scripts.Characters.Titan
         }
 
         [PunRPC]
-        public override void OnNapeHitRpc(int viewID, int damage, PhotonMessageInfo info)
+        public override void OnNapeHitRpc(int viewID, int damage, PhotonMessageInfo info = new PhotonMessageInfo())
         {
             Transform transform = base.transform.Find("Amarture/Core/Controller_Body/hip/spine/chest/neck");
             PhotonView view = PhotonView.Find(viewID);

--- a/Assets/Scripts/Characters/Titan/ColossalTitan.cs
+++ b/Assets/Scripts/Characters/Titan/ColossalTitan.cs
@@ -565,7 +565,7 @@ namespace Assets.Scripts.Characters.Titan
         }
 
         [PunRPC]
-        public override void OnNapeHitRpc2(int viewID, int damage, PhotonMessageInfo info)
+        public override void OnNapeHitRpc(int viewID, int damage, PhotonMessageInfo info)
         {
             Transform transform = base.transform.Find("Amarture/Core/Controller_Body/hip/spine/chest/neck");
             PhotonView view = PhotonView.Find(viewID);

--- a/Assets/Scripts/Characters/Titan/ErenTitan.cs
+++ b/Assets/Scripts/Characters/Titan/ErenTitan.cs
@@ -146,7 +146,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.connected && photonView.isMine)
             {
                 object[] parameters = new object[] { aniName, time };
-                photonView.RPC("netCrossFade", PhotonTargets.Others, parameters);
+                photonView.RPC(nameof(netCrossFade), PhotonTargets.Others, parameters);
             }
         }
 
@@ -422,7 +422,7 @@ namespace Assets.Scripts.Characters.Titan
         public void hitByFTByServer(int phase)
         {
             object[] parameters = new object[] { phase };
-            photonView.RPC("hitByFTRPC", PhotonTargets.All, parameters);
+            photonView.RPC(nameof(hitByFTRPC), PhotonTargets.All, parameters);
         }
 
         [PunRPC]
@@ -450,7 +450,7 @@ namespace Assets.Scripts.Characters.Titan
                     //TODO: 160, game lose
                     //this.gameWin2();
                     object[] parameters = new object[] { "set" };
-                    photonView.RPC("rockPlayAnimation", PhotonTargets.All, parameters);
+                    photonView.RPC(nameof(rockPlayAnimation), PhotonTargets.All, parameters);
                 }
                 else
                 {
@@ -465,7 +465,7 @@ namespace Assets.Scripts.Characters.Titan
 
         public void hitByTitanByServer()
         {
-            photonView.RPC("hitByTitanRPC", PhotonTargets.All, new object[0]);
+            photonView.RPC(nameof(hitByTitanRPC), PhotonTargets.All, new object[0]);
         }
 
         [PunRPC]
@@ -495,7 +495,7 @@ namespace Assets.Scripts.Characters.Titan
         {
             if (photonView.isMine && (((int) FengGameManagerMKII.settings[1]) == 1))
             {
-                photonView.RPC("loadskinRPC", PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x41] });
+                photonView.RPC(nameof(loadskinRPC), PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x41] });
             }
         }
 
@@ -593,7 +593,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.connected && photonView.isMine)
             {
                 object[] parameters = new object[] { aniName };
-                photonView.RPC("netPlayAnimation", PhotonTargets.Others, parameters);
+                photonView.RPC(nameof(netPlayAnimation), PhotonTargets.Others, parameters);
             }
         }
 
@@ -604,7 +604,7 @@ namespace Assets.Scripts.Characters.Titan
             if (PhotonNetwork.connected && photonView.isMine)
             {
                 object[] parameters = new object[] { aniName, normalizedTime };
-                photonView.RPC("netPlayAnimationAt", PhotonTargets.Others, parameters);
+                photonView.RPC(nameof(netPlayAnimationAt), PhotonTargets.Others, parameters);
             }
         }
 
@@ -698,7 +698,7 @@ namespace Assets.Scripts.Characters.Titan
                             rockPhase++;
                             crossFade("rock_lift", 0.1f);
                             object[] parameters = new object[] { "lift" };
-                            photonView.RPC("rockPlayAnimation", PhotonTargets.All, parameters);
+                            photonView.RPC(nameof(rockPlayAnimation), PhotonTargets.All, parameters);
                             waitCounter = 0f;
                             targetCheckPt = (Vector3) checkPoints[0];
                         }
@@ -713,10 +713,10 @@ namespace Assets.Scripts.Characters.Titan
                             rockPhase++;
                             crossFade("rock_walk", 0.1f);
                             object[] objArray3 = new object[] { "move" };
-                            photonView.RPC("rockPlayAnimation", PhotonTargets.All, objArray3);
+                            photonView.RPC(nameof(rockPlayAnimation), PhotonTargets.All, objArray3);
                             rock.GetComponent<Animation>()["move"].normalizedTime = GetComponent<Animation>()["rock_walk"].normalizedTime;
                             waitCounter = 0f;
-                            photonView.RPC("startMovingRock", PhotonTargets.All, new object[0]);
+                            photonView.RPC(nameof(startMovingRock), PhotonTargets.All, new object[0]);
                         }
                     }
                     else if (rockPhase == 5)
@@ -803,8 +803,8 @@ namespace Assets.Scripts.Characters.Titan
                         rockPhase++;
                         crossFade("rock_fix_hole", 0.1f);
                         object[] objArray4 = new object[] { "set" };
-                        photonView.RPC("rockPlayAnimation", PhotonTargets.All, objArray4);
-                        photonView.RPC("endMovingRock", PhotonTargets.All, new object[0]);
+                        photonView.RPC(nameof(rockPlayAnimation), PhotonTargets.All, objArray4);
+                        photonView.RPC(nameof(endMovingRock), PhotonTargets.All, new object[0]);
                     }
                     else if (rockPhase == 7)
                     {
@@ -1218,7 +1218,7 @@ namespace Assets.Scripts.Characters.Titan
                                     if (PhotonNetwork.isMasterClient)
                                     {
                                         object[] parameters = new object[] { 10f, 500f };
-                                        photonView.RPC("netTauntAttack", PhotonTargets.MasterClient, parameters);
+                                        photonView.RPC(nameof(netTauntAttack), PhotonTargets.MasterClient, parameters);
                                     }
                                     else
                                     {

--- a/Assets/Scripts/Characters/Titan/FemaleTitan.cs
+++ b/Assets/Scripts/Characters/Titan/FemaleTitan.cs
@@ -1417,7 +1417,7 @@ public class FemaleTitan : TitanBase
     }
 
     [PunRPC]
-    public override void OnNapeHitRpc(int viewID, int speed, PhotonMessageInfo info)
+    public override void OnNapeHitRpc(int viewID, int speed, PhotonMessageInfo info = new PhotonMessageInfo())
     {
         Transform transform = base.transform.Find("Amarture/Core/Controller_Body/hip/spine/chest/neck");
         PhotonView view = PhotonView.Find(viewID);

--- a/Assets/Scripts/Characters/Titan/FemaleTitan.cs
+++ b/Assets/Scripts/Characters/Titan/FemaleTitan.cs
@@ -13,6 +13,7 @@ using UnityEngine;
 public class FemaleTitan : TitanBase
 {
     private GamemodeBase Gamemode { get; set; }
+    private FengGameManagerMKII GameManager { get; set; }
 
     [CompilerGenerated]
     public static Dictionary<string, int> f__switchSmap1;
@@ -565,6 +566,7 @@ public class FemaleTitan : TitanBase
         base.Awake();
         base.GetComponent<Rigidbody>().freezeRotation = true;
         base.GetComponent<Rigidbody>().useGravity = false;
+        GameManager = FengGameManagerMKII.instance;
     }
 
     public void beTauntedBy(GameObject target, float tauntTime)
@@ -631,48 +633,48 @@ public class FemaleTitan : TitanBase
         if (PhotonNetwork.isMasterClient)
         {
             object[] parameters = new object[] { aniName, time };
-            base.photonView.RPC("netCrossFade", PhotonTargets.Others, parameters);
+            base.photonView.RPC(nameof(netCrossFade), PhotonTargets.Others, parameters);
         }
     }
 
-    private void eatSet(GameObject grabTarget)
+    private void EatSet(Hero grabTarget)
     {
-        if (!grabTarget.GetComponent<Hero>().isGrabbed)
+        if (!grabTarget.isGrabbed)
         {
             this.grabToRight();
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { base.photonView.viewID, false };
-                grabTarget.GetPhotonView().RPC("netGrabbed", PhotonTargets.All, parameters);
+                grabTarget.photonView.RPC("netGrabbed", PhotonTargets.All, parameters);
                 object[] objArray2 = new object[] { "grabbed" };
-                grabTarget.GetPhotonView().RPC("netPlayAnimation", PhotonTargets.All, objArray2);
-                base.photonView.RPC("grabToRight", PhotonTargets.Others, new object[0]);
+                grabTarget.photonView.RPC("netPlayAnimation", PhotonTargets.All, objArray2);
+                base.photonView.RPC(nameof(grabToRight), PhotonTargets.Others, new object[0]);
             }
             else
             {
-                grabTarget.GetComponent<Hero>().grabbed(base.gameObject, false);
-                grabTarget.GetComponent<Hero>().GetComponent<Animation>().Play("grabbed");
+                grabTarget.grabbed(base.gameObject, false);
+                grabTarget.GetComponent<Animation>().Play("grabbed");
             }
         }
     }
 
-    private void eatSetL(GameObject grabTarget)
+    private void EatSetL(Hero grabTarget)
     {
-        if (!grabTarget.GetComponent<Hero>().isGrabbed)
+        if (!grabTarget.isGrabbed)
         {
             this.grabToLeft();
             if (PhotonNetwork.isMasterClient)
             {
                 object[] parameters = new object[] { base.photonView.viewID, true };
-                grabTarget.GetPhotonView().RPC("netGrabbed", PhotonTargets.All, parameters);
+                grabTarget.photonView.RPC("netGrabbed", PhotonTargets.All, parameters);
                 object[] objArray2 = new object[] { "grabbed" };
-                grabTarget.GetPhotonView().RPC("netPlayAnimation", PhotonTargets.All, objArray2);
-                base.photonView.RPC("grabToLeft", PhotonTargets.Others, new object[0]);
+                grabTarget.photonView.RPC("netPlayAnimation", PhotonTargets.All, objArray2);
+                base.photonView.RPC(nameof(grabToLeft), PhotonTargets.Others, new object[0]);
             }
             else
             {
-                grabTarget.GetComponent<Hero>().grabbed(base.gameObject, true);
-                grabTarget.GetComponent<Hero>().GetComponent<Animation>().Play("grabbed");
+                grabTarget.grabbed(base.gameObject, true);
+                grabTarget.GetComponent<Animation>().Play("grabbed");
             }
         }
     }
@@ -962,9 +964,9 @@ public class FemaleTitan : TitanBase
                     {
                         this.getDown();
                     }
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's ankle", dmg);
+                    GameManager.sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's ankle", dmg);
                     object[] parameters = new object[] { dmg };
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().photonView.RPC("netShowDamage", view.owner, parameters);
+                    GameManager.photonView.RPC("netShowDamage", view.owner, parameters);
                 }
             }
         }
@@ -1002,9 +1004,9 @@ public class FemaleTitan : TitanBase
                     {
                         this.getDown();
                     }
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's ankle", dmg);
+                    GameManager.sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's ankle", dmg);
                     object[] parameters = new object[] { dmg };
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().photonView.RPC("netShowDamage", view.owner, parameters);
+                    GameManager.photonView.RPC("netShowDamage", view.owner, parameters);
                 }
             }
         }
@@ -1080,7 +1082,7 @@ public class FemaleTitan : TitanBase
             {
                 hitHero.GetComponent<Hero>().markDie();
                 object[] parameters = new object[] { (Vector3) (((hitHero.transform.position - position) * 15f) * 4f), false, -1, "Female Titan", true };
-                hitHero.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, parameters);
+                hitHero.GetComponent<Hero>().photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, parameters);
             }
         }
     }
@@ -1159,7 +1161,7 @@ public class FemaleTitan : TitanBase
     {
         if (((int) FengGameManagerMKII.settings[1]) == 1)
         {
-            base.photonView.RPC("loadskinRPC", PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x42] });
+            base.photonView.RPC(nameof(loadskinRPC), PhotonTargets.AllBuffered, new object[] { (string) FengGameManagerMKII.settings[0x42] });
         }
     }
 
@@ -1250,7 +1252,7 @@ public class FemaleTitan : TitanBase
         if (PhotonNetwork.isMasterClient)
         {
             object[] parameters = new object[] { aniName };
-            base.photonView.RPC("netPlayAnimation", PhotonTargets.Others, parameters);
+            base.photonView.RPC(nameof(netPlayAnimation), PhotonTargets.Others, parameters);
         }
     }
 
@@ -1261,7 +1263,7 @@ public class FemaleTitan : TitanBase
         if (PhotonNetwork.isMasterClient)
         {
             object[] parameters = new object[] { aniName, normalizedTime };
-            base.photonView.RPC("netPlayAnimationAt", PhotonTargets.Others, parameters);
+            base.photonView.RPC(nameof(netPlayAnimationAt), PhotonTargets.Others, parameters);
         }
     }
 
@@ -1269,7 +1271,7 @@ public class FemaleTitan : TitanBase
     {
         this.playsoundRPC(sndname);
         object[] parameters = new object[] { sndname };
-        base.photonView.RPC("playsoundRPC", PhotonTargets.Others, parameters);
+        base.photonView.RPC(nameof(playsoundRPC), PhotonTargets.Others, parameters);
     }
 
     [PunRPC]
@@ -1298,7 +1300,7 @@ public class FemaleTitan : TitanBase
         if (base.photonView.isMine)
         {
             //size = GameSettings.Titan.Female.Size.Value;
-            base.photonView.RPC("setSize", PhotonTargets.AllBuffered, new object[] { this.size });
+            base.photonView.RPC(nameof(setSize), PhotonTargets.AllBuffered, new object[] { this.size });
             this.lagMax = 150f + (this.size * 3f);
             this.healthTime = 0f;
             this.maxHealth = this.Health;
@@ -1308,7 +1310,7 @@ public class FemaleTitan : TitanBase
             }
             if (this.Health > 0)
             {
-                base.photonView.RPC("labelRPC", PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
+                base.photonView.RPC(nameof(labelRPC), PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
             }
             this.loadskin();
         }
@@ -1432,14 +1434,14 @@ public class FemaleTitan : TitanBase
                 }
                 if (this.maxHealth > 0f)
                 {
-                    base.photonView.RPC("labelRPC", PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
+                    base.photonView.RPC(nameof(labelRPC), PhotonTargets.AllBuffered, new object[] { this.Health, this.maxHealth });
                 }
                 if (this.Health <= 0)
                 {
                     this.Health = 0;
                     if (!this.hasDie)
                     {
-                        base.photonView.RPC("netDie", PhotonTargets.OthersBuffered, new object[0]);
+                        base.photonView.RPC(nameof(netDie), PhotonTargets.OthersBuffered, new object[0]);
                         if (this.grabbedTarget != null)
                         {
                             this.grabbedTarget.GetPhotonView().RPC("netUngrabbed", PhotonTargets.All, new object[0]);
@@ -1450,9 +1452,9 @@ public class FemaleTitan : TitanBase
                 }
                 else
                 {
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's neck", speed);
+                    GameManager.sendKillInfo(false, (string) view.owner.CustomProperties[PhotonPlayerProperty.name], true, "Female Titan's neck", speed);
                     object[] parameters = new object[] { speed };
-                    GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().photonView.RPC("netShowDamage", view.owner, parameters);
+                    GameManager.photonView.RPC("netShowDamage", view.owner, parameters);
                 }
                 this.healthTime = 0.2f;
             }
@@ -1738,16 +1740,17 @@ public class FemaleTitan : TitanBase
                     if (((base.GetComponent<Animation>()["ft_attack_grab_" + this.attackAnimation].normalizedTime >= this.attackCheckTimeA) && (base.GetComponent<Animation>()["ft_attack_grab_" + this.attackAnimation].normalizedTime <= this.attackCheckTimeB)) && (this.grabbedTarget == null))
                     {
                         GameObject grabTarget = this.checkIfHitHand(this.currentGrabHand);
-                        if (grabTarget != null)
+                        if (grabTarget != null && grabTarget.GetComponent<Hero>() != null)
                         {
+                            var hero = grabTarget.GetComponent<Hero>();
                             if (this.isGrabHandLeft)
                             {
-                                this.eatSetL(grabTarget);
+                                this.EatSetL(hero);
                                 this.grabbedTarget = grabTarget;
                             }
                             else
                             {
-                                this.eatSet(grabTarget);
+                                this.EatSet(hero);
                                 this.grabbedTarget = grabTarget;
                             }
                         }

--- a/Assets/Scripts/Characters/Titan/FemaleTitan.cs
+++ b/Assets/Scripts/Characters/Titan/FemaleTitan.cs
@@ -1417,7 +1417,7 @@ public class FemaleTitan : TitanBase
     }
 
     [PunRPC]
-    public override void OnNapeHitRpc2(int viewID, int speed, PhotonMessageInfo info)
+    public override void OnNapeHitRpc(int viewID, int speed, PhotonMessageInfo info)
     {
         Transform transform = base.transform.Find("Amarture/Core/Controller_Body/hip/spine/chest/neck");
         PhotonView view = PhotonView.Find(viewID);

--- a/Assets/Scripts/Characters/Titan/MindlessTitan.cs
+++ b/Assets/Scripts/Characters/Titan/MindlessTitan.cs
@@ -367,36 +367,6 @@ namespace Assets.Scripts.Characters.Titan
             }
         }
 
-        [PunRPC]
-        protected void UpdateHealthLabelRpc(int currentHealth, int maxHealth)
-        {
-            if (currentHealth < 0)
-            {
-                if (HealthLabel != null)
-                {
-                    Destroy(HealthLabel);
-                }
-            }
-            else
-            {
-                var color = "7FFF00";
-                var num2 = ((float)currentHealth) / ((float)maxHealth);
-                if ((num2 < 0.75f) && (num2 >= 0.5f))
-                {
-                    color = "f2b50f";
-                }
-                else if ((num2 < 0.5f) && (num2 >= 0.25f))
-                {
-                    color = "ff8100";
-                }
-                else if (num2 < 0.25f)
-                {
-                    color = "ff3333";
-                }
-                HealthLabel.GetComponent<TextMesh>().text = $"<color=#{color}>{currentHealth}</color>";
-            }
-        }
-
         public void OnAnkleHit(int viewId, int damage) { }
 
         private float bodyPartDamageTimer;

--- a/Assets/Scripts/Characters/Titan/MindlessTitan.cs
+++ b/Assets/Scripts/Characters/Titan/MindlessTitan.cs
@@ -302,7 +302,7 @@ namespace Assets.Scripts.Characters.Titan
                         {
                             this.asClientLookTarget = true;
                             object[] parameters = new object[] {true};
-                            base.photonView.RPC("setIfLookTarget", PhotonTargets.Others, parameters);
+                            base.photonView.RPC(nameof(setIfLookTarget), PhotonTargets.Others, parameters);
                         }
 
                         flag2 = true;
@@ -312,7 +312,7 @@ namespace Assets.Scripts.Characters.Titan
                     {
                         this.asClientLookTarget = false;
                         object[] objArray3 = new object[] {false};
-                        base.photonView.RPC("setIfLookTarget", PhotonTargets.Others, objArray3);
+                        base.photonView.RPC(nameof(setIfLookTarget), PhotonTargets.Others, objArray3);
                     }
 
                     if (State == TitanState.Attacking)

--- a/Assets/Scripts/Characters/Titan/MindlessTitan.cs
+++ b/Assets/Scripts/Characters/Titan/MindlessTitan.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Assets.Scripts.Gamemode.Options;
 using UnityEngine;
 using Random = UnityEngine.Random;
 

--- a/Assets/Scripts/Characters/Titan/PlayerTitan.cs
+++ b/Assets/Scripts/Characters/Titan/PlayerTitan.cs
@@ -159,9 +159,9 @@ namespace Assets.Scripts.Characters.Titan
             return false;
         }
 
-        protected override void OnTitanDeath()
+        protected override void OnDeath()
         {
-            base.OnTitanDeath();
+            base.OnDeath();
             if (!photonView.isMine) return;
             this.currentCamera.GetComponent<IN_GAME_MAIN_CAMERA>().setMainObject(null, true, false);
             this.currentCamera.GetComponent<IN_GAME_MAIN_CAMERA>().setSpectorMode(true);
@@ -190,7 +190,7 @@ namespace Assets.Scripts.Characters.Titan
                 // PhotonNetwork.Destroy(base.photonView);
                 GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().sendKillInfo(false, string.Empty, true, (string) PhotonNetwork.player.customProperties[PhotonPlayerProperty.name], 0);
                 GameObject.Find("MultiplayerManager").GetComponent<FengGameManagerMKII>().needChooseSide = true;
-                ChangeState(TitanState.Dead);
+                SetState(TitanState.Dead);
                 Dead();
             }
         }
@@ -236,7 +236,7 @@ namespace Assets.Scripts.Characters.Titan
                     CrossFade(CurrentAnimation, 0.1f);
                     return;
                 }
-                ChangeState(TitanState.Wandering);
+                SetState(TitanState.Wandering);
             }
 
             if (IsCovering && Animation.IsPlaying(AnimationCover) && Animation[AnimationCover].normalizedTime < 1f)

--- a/Assets/Scripts/Characters/Titan/RockThrow.cs
+++ b/Assets/Scripts/Characters/Titan/RockThrow.cs
@@ -47,7 +47,7 @@ public class RockThrow : Photon.MonoBehaviour
                 }
                 Debug.Log("rock hit player " + titanName);
                 object[] parameters = new object[] { (Vector3) ((this.v.normalized * 1000f) + (Vector3.up * 50f)), false, myOwnerViewID, titanName, true };
-                hero.GetComponent<Hero>().photonView.RPC("netDie", PhotonTargets.All, parameters);
+                hero.GetComponent<Hero>().photonView.RPC(nameof(Hero.netDie), PhotonTargets.All, parameters);
             }
         }
     }
@@ -70,7 +70,7 @@ public class RockThrow : Photon.MonoBehaviour
         if (PhotonNetwork.isMasterClient)
         {
             object[] parameters = new object[] { this.v, this.oldP };
-            base.photonView.RPC("launchRPC", PhotonTargets.Others, parameters);
+            base.photonView.RPC(nameof(launchRPC), PhotonTargets.Others, parameters);
         }
     }
 

--- a/Assets/Scripts/Characters/Titan/TITAN_SETUP.cs
+++ b/Assets/Scripts/Characters/Titan/TITAN_SETUP.cs
@@ -134,13 +134,13 @@ public class TITAN_SETUP : Photon.MonoBehaviour
                 if (flag2)
                 {
                     objArray2 = new object[] { num, eye, hairlink };
-                    base.photonView.RPC("setHairRPC2", PhotonTargets.AllBuffered, objArray2);
+                    base.photonView.RPC(nameof(setHairRPC2), PhotonTargets.AllBuffered, objArray2);
                 }
                 else
                 {
                     color = HeroCostume.costume[UnityEngine.Random.Range(0, HeroCostume.costume.Length - 5)].hair_color;
                     objArray2 = new object[] { num, eye, color.r, color.g, color.b };
-                    base.photonView.RPC("setHairPRC", PhotonTargets.AllBuffered, objArray2);
+                    base.photonView.RPC(nameof(setHairPRC), PhotonTargets.AllBuffered, objArray2);
                 }
             }
         }
@@ -171,7 +171,7 @@ public class TITAN_SETUP : Photon.MonoBehaviour
             if (base.photonView.isMine)
             {
                 objArray2 = new object[] { this.hairType, id, this.part_hair.GetComponent<Renderer>().material.color.r, this.part_hair.GetComponent<Renderer>().material.color.g, this.part_hair.GetComponent<Renderer>().material.color.b };
-                base.photonView.RPC("setHairPRC", PhotonTargets.OthersBuffered, objArray2);
+                base.photonView.RPC(nameof(setHairPRC), PhotonTargets.OthersBuffered, objArray2);
             }
         }
     }

--- a/Assets/Scripts/Characters/Titan/TitanBase.cs
+++ b/Assets/Scripts/Characters/Titan/TitanBase.cs
@@ -347,18 +347,19 @@ namespace Assets.Scripts.Characters.Titan
             Rigidbody.AddForce(direction * 50f, ForceMode.VelocityChange);
             if (this is MindlessTitan t)
             {
-                t.OnNapeHitRpc(attacker.photonView.viewID, damage);
+                t.photonView.RPC(nameof(OnNapeHitRpc), PhotonTargets.All, attacker.photonView.viewID, damage);
             }
             else
             {
-                photonView.RPC(nameof(OnNapeHitRpc2), PhotonTargets.All, attacker.photonView.viewID, damage);
+                photonView.RPC(nameof(OnNapeHitRpc), PhotonTargets.All, attacker.photonView.viewID, damage);
             }
         }
 
         [Obsolete("Blocking all damage for 0.2s isn't viable. Instead block this per view ID instead of all")]
         private float DamageTimer { get; set; }
+
         [PunRPC]
-        public virtual void OnNapeHitRpc2(int viewId, int damage, PhotonMessageInfo info)
+        public virtual void OnNapeHitRpc(int viewId, int damage, PhotonMessageInfo info)
         {
             if (!IsAlive) return;
             var view = PhotonView.Find(viewId);
@@ -431,7 +432,7 @@ namespace Assets.Scripts.Characters.Titan
 
         #region Titan State Logic
 
-        protected virtual void SetState(TitanState state)
+        public virtual void SetState(TitanState state)
         {
             if (!IsAlive) return;
             if (state == State) return;

--- a/Assets/Scripts/Characters/Titan/TitanBase.cs
+++ b/Assets/Scripts/Characters/Titan/TitanBase.cs
@@ -383,7 +383,7 @@ namespace Assets.Scripts.Characters.Titan
 
             if (MaxHealth > 0)
             {
-                photonView.RPC(nameof(UpdateHealthLabelRpc2), PhotonTargets.All, Health, MaxHealth);
+                photonView.RPC(nameof(UpdateHealthLabelRpc), PhotonTargets.All, Health, MaxHealth);
             }
 
             if (Health <= 0)
@@ -401,7 +401,7 @@ namespace Assets.Scripts.Characters.Titan
         }
 
         [PunRPC]
-        protected void UpdateHealthLabelRpc2(int currentHealth, int maxHealth)
+        protected void UpdateHealthLabelRpc(int currentHealth, int maxHealth)
         {
             if (currentHealth < 0)
             {

--- a/Assets/Scripts/Characters/Titan/TitanBase.cs
+++ b/Assets/Scripts/Characters/Titan/TitanBase.cs
@@ -359,7 +359,7 @@ namespace Assets.Scripts.Characters.Titan
         private float DamageTimer { get; set; }
 
         [PunRPC]
-        public virtual void OnNapeHitRpc(int viewId, int damage, PhotonMessageInfo info)
+        public virtual void OnNapeHitRpc(int viewId, int damage, PhotonMessageInfo info = new PhotonMessageInfo())
         {
             if (!IsAlive) return;
             var view = PhotonView.Find(viewId);

--- a/Assets/Scripts/Events/Args/HeroHitEvent.cs
+++ b/Assets/Scripts/Events/Args/HeroHitEvent.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Assets.Scripts.Events.Args
 {

--- a/Assets/Scripts/Events/Args/HeroHitEvent.cs
+++ b/Assets/Scripts/Events/Args/HeroHitEvent.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Assets.Scripts.Events.Args
+{
+    public class HeroHitEvent : EventArgs
+    {
+        public HeroHitEvent(Hero victim, Hero hitter)
+        {
+            Victim = victim;
+            Hitter = hitter;
+        }
+
+        /// <summary>
+        /// Gets the killed <see cref="Hero"/>.
+        /// </summary>
+        public Hero Victim { get; }
+
+        /// <summary>
+        /// Gets the attacking <see cref="Hero"/>.
+        /// </summary>
+        public Hero Hitter { get; }
+    }
+}

--- a/Assets/Scripts/Events/HitEvents.cs
+++ b/Assets/Scripts/Events/HitEvents.cs
@@ -2,7 +2,9 @@
 
 namespace Assets.Scripts.Events
 {
-    public delegate void OnHeroHit(HeroKillEvent heroKillEvent);
+    public delegate void OnHeroHit(HeroHitEvent heroKillEvent);
+
+    public delegate void OnHeroKill(HeroKillEvent heroKillEvent);
 
     public delegate void OnTitanDamaged(TitanDamagedEvent titanDamagedEvent);
 

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -2804,7 +2804,10 @@ namespace Assets.Scripts
             Damage = Mathf.Max(10, Damage);
             object[] parameters = new object[] { Damage };
             base.photonView.RPC("netShowDamage", player, parameters);
-            this.sendKillInfo(false, (string) player.CustomProperties[PhotonPlayerProperty.name], true, name, Damage);
+            if (!PhotonNetwork.offlineMode)
+            {
+                this.sendKillInfo(false, (string) player.CustomProperties[PhotonPlayerProperty.name], true, name, Damage);
+            }
             this.playerKillInfoUpdate(player, Damage);
         }
 
@@ -2825,7 +2828,7 @@ namespace Assets.Scripts
         }
 
         [PunRPC]
-        private void updateKillInfo(bool t1, string killer, bool t2, string victim, int dmg)
+        private void updateKillInfo(bool killerIsTitan, string killer, bool victimIsTitan, string victim, int dmg)
         {
             var killFeed = GameObject.Find("KillFeed");
             var newKillInfo = (GameObject) UnityEngine.Object.Instantiate(Resources.Load("UI/KillInfo"));
@@ -2849,7 +2852,7 @@ namespace Assets.Scripts
 
             newKillInfo.transform.parent = killFeed.transform;
             newKillInfo.transform.position = new Vector3();
-            newKillInfo.GetComponent<KillInfo>().Show(t1, killer, t2, victim, dmg);
+            newKillInfo.GetComponent<KillInfo>().Show(killerIsTitan, killer, victimIsTitan, victim, dmg);
             killInfoGO.Add(newKillInfo);
         }
 

--- a/Assets/Scripts/FengGameManagerMKII.cs
+++ b/Assets/Scripts/FengGameManagerMKII.cs
@@ -693,7 +693,7 @@ namespace Assets.Scripts
             {
                 PhotonNetwork.DestroyPlayerObjects(player);
                 PhotonNetwork.CloseConnection(player);
-                base.photonView.RPC("ignorePlayer", PhotonTargets.Others, new object[] { player.ID });
+                base.photonView.RPC(nameof(ignorePlayer), PhotonTargets.Others, new object[] { player.ID });
                 if (!ignoreList.Contains(player.ID))
                 {
                     ignoreList.Add(player.ID);
@@ -1078,7 +1078,7 @@ namespace Assets.Scripts
                 if (PhotonNetwork.isMasterClient)
                 {
                     oldScriptLogic = currentScriptLogic;
-                    base.photonView.RPC("setMasterRC", PhotonTargets.All, new object[0]);
+                    base.photonView.RPC(nameof(setMasterRC), PhotonTargets.All, new object[0]);
                 }
                 logicLoaded = true;
                 this.racingSpawnPoint = new Vector3(0f, 0f, 0f);
@@ -1179,7 +1179,7 @@ namespace Assets.Scripts
                             strArray3[num] = (string) settings[num + 0xaf];
                         }
                         strArray3[6] = (string) settings[0xa2];
-                        base.photonView.RPC("clearlevel", PhotonTargets.AllBuffered, new object[] { strArray3 });
+                        base.photonView.RPC(nameof(clearlevel), PhotonTargets.AllBuffered, new object[] { strArray3 });
                         if (oldScript != currentScript)
                         {
                             ExitGames.Client.Photon.Hashtable hashtable;
@@ -1701,7 +1701,7 @@ namespace Assets.Scripts
             else
             {
                 object[] parameters = new object[] { LoginFengKAI.player.name, time };
-                base.photonView.RPC("getRacingResult", PhotonTargets.MasterClient, parameters);
+                base.photonView.RPC(nameof(getRacingResult), PhotonTargets.MasterClient, parameters);
             }
         }
 
@@ -1955,7 +1955,7 @@ namespace Assets.Scripts
                 if (!(this.gameTimesUp || !PhotonNetwork.isMasterClient))
                 {
                     this.restartGame2(true);
-                    base.photonView.RPC("setMasterRC", PhotonTargets.All, new object[0]);
+                    base.photonView.RPC(nameof(setMasterRC), PhotonTargets.All, new object[0]);
                 }
             }
             noRestart = false;
@@ -2016,9 +2016,9 @@ namespace Assets.Scripts
                     ExitGames.Client.Photon.Hashtable hashtable = new ExitGames.Client.Photon.Hashtable();
                     if ((ignoreList != null) && (ignoreList.Count > 0))
                     {
-                        photonView.RPC("ignorePlayerArray", player, new object[] { ignoreList.ToArray() });
+                        photonView.RPC(nameof(ignorePlayerArray), player, new object[] { ignoreList.ToArray() });
                     }
-                    photonView.RPC("setMasterRC", player, new object[0]);
+                    photonView.RPC(nameof(setMasterRC), player, new object[0]);
                 }
             }
             this.RecompilePlayerList(0.1f);
@@ -2033,7 +2033,7 @@ namespace Assets.Scripts
             InstantiateTracker.instance.TryRemovePlayer(player.ID);
             if (PhotonNetwork.isMasterClient)
             {
-                base.photonView.RPC("verifyPlayerHasLeft", PhotonTargets.All, new object[] { player.ID });
+                base.photonView.RPC(nameof(verifyPlayerHasLeft), PhotonTargets.All, new object[] { player.ID });
             }
             if (GameSettings.Gamemode.SaveKDROnDisconnect.Value)
             {
@@ -2143,7 +2143,7 @@ namespace Assets.Scripts
                 this.localRacingResult = this.localRacingResult + "\n";
             }
             object[] parameters = new object[] { this.localRacingResult };
-            base.photonView.RPC("netRefreshRacingResult", PhotonTargets.All, parameters);
+            base.photonView.RPC(nameof(netRefreshRacingResult), PhotonTargets.All, parameters);
         }
 
         public IEnumerator reloadSky()
@@ -2219,7 +2219,7 @@ namespace Assets.Scripts
                     PhotonPlayer targetPlayer = PhotonNetwork.playerList[j];
                     if (((targetPlayer.CustomProperties[PhotonPlayerProperty.RCteam] == null) && RCextensions.returnBoolFromObject(targetPlayer.CustomProperties[PhotonPlayerProperty.dead])) && (RCextensions.returnIntFromObject(targetPlayer.CustomProperties[PhotonPlayerProperty.isTitan]) != 2))
                     {
-                        this.photonView.RPC("respawnHeroInNewRound", targetPlayer, new object[0]);
+                        this.photonView.RPC(nameof(respawnHeroInNewRound), targetPlayer, new object[0]);
                     }
                 }
             }
@@ -2321,13 +2321,13 @@ namespace Assets.Scripts
         public void sendChatContentInfo(string content)
         {
             object[] parameters = new object[] { content, string.Empty };
-            base.photonView.RPC("Chat", PhotonTargets.All, parameters);
+            base.photonView.RPC(nameof(Chat), PhotonTargets.All, parameters);
         }
 
         public void sendKillInfo(bool t1, string killer, bool t2, string victim, int dmg = 0)
         {
             object[] parameters = new object[] { t1, killer, t2, victim, dmg };
-            base.photonView.RPC("updateKillInfo", PhotonTargets.All, parameters);
+            base.photonView.RPC(nameof(updateKillInfo), PhotonTargets.All, parameters);
         }
 
         public static void ServerCloseConnection(PhotonPlayer targetPlayer, bool requestIpBan, string inGameName = null)
@@ -2450,7 +2450,7 @@ namespace Assets.Scripts
                 {
                     if (obj2.GetPhotonView().isMine)
                     {
-                        base.photonView.RPC("labelRPC", PhotonTargets.All, new object[] { obj2.GetPhotonView().viewID });
+                        base.photonView.RPC(nameof(labelRPC), PhotonTargets.All, new object[] { obj2.GetPhotonView().viewID });
                     }
                 }
             }
@@ -2803,7 +2803,7 @@ namespace Assets.Scripts
         {
             Damage = Mathf.Max(10, Damage);
             object[] parameters = new object[] { Damage };
-            base.photonView.RPC("netShowDamage", player, parameters);
+            base.photonView.RPC(nameof(netShowDamage), player, parameters);
             if (!PhotonNetwork.offlineMode)
             {
                 this.sendKillInfo(false, (string) player.CustomProperties[PhotonPlayerProperty.name], true, name, Damage);
@@ -3034,7 +3034,7 @@ namespace Assets.Scripts
                             }
                             if (num12 > 0)
                             {
-                                this.photonView.RPC("setTeamRPC", player2, new object[] { num12 });
+                                this.photonView.RPC(nameof(setTeamRPC), player2, new object[] { num12 });
                             }
                         }
                     }
@@ -3070,7 +3070,7 @@ namespace Assets.Scripts
                                 }
                                 if (num13 > 0)
                                 {
-                                    this.photonView.RPC("setTeamRPC", player3, new object[] { num13 });
+                                    this.photonView.RPC(nameof(setTeamRPC), player3, new object[] { num13 });
                                 }
                             }
                         }
@@ -3269,14 +3269,14 @@ namespace Assets.Scripts
                         if (this.cyanKills >= GameSettings.Gamemode.PointMode)
                         {
                             object[] parameters = new object[] { "<color=#00FFFF>Team Cyan wins! </color>", string.Empty };
-                            this.photonView.RPC("Chat", PhotonTargets.All, parameters);
+                            this.photonView.RPC(nameof(Chat), PhotonTargets.All, parameters);
                             //TODO: 160, game won
                             //this.gameWin2();
                         }
                         else if (this.magentaKills >= GameSettings.Gamemode.PointMode)
                         {
                             objArray2 = new object[] { "<color=#FF00FF>Team Magenta wins! </color>", string.Empty };
-                            this.photonView.RPC("Chat", PhotonTargets.All, objArray2);
+                            this.photonView.RPC(nameof(Chat), PhotonTargets.All, objArray2);
                             //TODO: 160, game won
                             //this.gameWin2();
                         }
@@ -3289,7 +3289,7 @@ namespace Assets.Scripts
                             if (RCextensions.returnIntFromObject(player9.CustomProperties[PhotonPlayerProperty.kills]) >= GameSettings.Gamemode.PointMode)
                             {
                                 object[] objArray4 = new object[] { "<color=#FFCC00>" + RCextensions.returnStringFromObject(player9.CustomProperties[PhotonPlayerProperty.name]).hexColor() + " wins!</color>", string.Empty };
-                                this.photonView.RPC("Chat", PhotonTargets.All, objArray4);
+                                this.photonView.RPC(nameof(Chat), PhotonTargets.All, objArray4);
                                 //TODO: 160, game won
                                 //this.gameWin2();
                             }
@@ -3334,14 +3334,14 @@ namespace Assets.Scripts
                                 if (num24 == 0)
                                 {
                                     object[] objArray5 = new object[] { "<color=#FF00FF>Team Magenta wins! </color>", string.Empty };
-                                    this.photonView.RPC("Chat", PhotonTargets.All, objArray5);
+                                    this.photonView.RPC(nameof(Chat), PhotonTargets.All, objArray5);
                                     //TODO: 160, game won
                                     //this.gameWin2();
                                 }
                                 else if (num25 == 0)
                                 {
                                     object[] objArray6 = new object[] { "<color=#00FFFF>Team Cyan wins! </color>", string.Empty };
-                                    this.photonView.RPC("Chat", PhotonTargets.All, objArray6);
+                                    this.photonView.RPC(nameof(Chat), PhotonTargets.All, objArray6);
                                     //TODO: 160, game won
                                     //this.gameWin2();
                                 }
@@ -3377,7 +3377,7 @@ namespace Assets.Scripts
                                     }
                                 }
                                 object[] objArray7 = new object[] { "<color=#FFCC00>" + text.hexColor() + " wins." + str4 + "</color>", string.Empty };
-                                this.photonView.RPC("Chat", PhotonTargets.All, objArray7);
+                                this.photonView.RPC(nameof(Chat), PhotonTargets.All, objArray7);
                                 //TODO: 160, game won
                                 //this.gameWin2();
                             }

--- a/Assets/Scripts/Gamemode/Capture/PVPcheckPoint.cs
+++ b/Assets/Scripts/Gamemode/Capture/PVPcheckPoint.cs
@@ -156,7 +156,7 @@ public class PVPcheckPoint : Photon.MonoBehaviour
             this.syncPts();
             this.state = CheckPointState.Human;
             object[] parameters = new object[] { 1 };
-            base.photonView.RPC("changeState", PhotonTargets.All, parameters);
+            base.photonView.RPC(nameof(changeState), PhotonTargets.All, parameters);
             if (GameSettings.DerivedGamemode<CaptureGamemodeSettings>().SpawnSupplyStationOnHumanCapture.Value)
             {
                 supply = PhotonNetwork.Instantiate("aot_supply", transform.position - (Vector3.up * (transform.position.y - getHeight(transform.position))), transform.rotation, 0);
@@ -188,7 +188,7 @@ public class PVPcheckPoint : Photon.MonoBehaviour
                 {
                     this.state = CheckPointState.Non;
                     object[] parameters = new object[] { 0 };
-                    base.photonView.RPC("changeState", PhotonTargets.Others, parameters);
+                    base.photonView.RPC(nameof(changeState), PhotonTargets.Others, parameters);
                 }
             }
         }
@@ -256,9 +256,9 @@ public class PVPcheckPoint : Photon.MonoBehaviour
     private void syncPts()
     {
         object[] parameters = new object[] { this.titanPt };
-        base.photonView.RPC("changeTitanPt", PhotonTargets.Others, parameters);
+        base.photonView.RPC(nameof(changeTitanPt), PhotonTargets.Others, parameters);
         object[] objArray2 = new object[] { this.humanPt };
-        base.photonView.RPC("changeHumanPt", PhotonTargets.Others, objArray2);
+        base.photonView.RPC(nameof(changeHumanPt), PhotonTargets.Others, objArray2);
     }
 
     private void titanGetsPoint()
@@ -274,7 +274,7 @@ public class PVPcheckPoint : Photon.MonoBehaviour
             }
             this.state = CheckPointState.Titan;
             object[] parameters = new object[] { 2 };
-            base.photonView.RPC("changeState", PhotonTargets.All, parameters);
+            base.photonView.RPC(nameof(changeState), PhotonTargets.All, parameters);
             gamemode.AddTitanScore(2);
             if (this.checkIfTitanWins() && PhotonNetwork.isMasterClient)
             {
@@ -317,7 +317,7 @@ public class PVPcheckPoint : Photon.MonoBehaviour
                 {
                     this.state = CheckPointState.Non;
                     object[] parameters = new object[] { 0 };
-                    base.photonView.RPC("changeState", PhotonTargets.All, parameters);
+                    base.photonView.RPC(nameof(changeState), PhotonTargets.All, parameters);
                 }
             }
         }

--- a/Assets/Scripts/Gamemode/InfectionGamemode.cs
+++ b/Assets/Scripts/Gamemode/InfectionGamemode.cs
@@ -60,7 +60,7 @@ namespace Assets.Scripts.Gamemode
                             ExitGames.Client.Photon.Hashtable propertiesToSet = new ExitGames.Client.Photon.Hashtable();
                             propertiesToSet.Add(PhotonPlayerProperty.isTitan, 2);
                             targetPlayer.SetCustomProperties(propertiesToSet);
-                            photonView.RPC("SpawnPlayerTitanRpc", targetPlayer, new object[0]);
+                            photonView.RPC(nameof(SpawnPlayerTitanRpc), targetPlayer, new object[0]);
                         }
                         else if (FengGameManagerMKII.imatitan.ContainsKey(targetPlayer.ID))
                         {

--- a/Assets/Scripts/Services/Interface/IPlayerService.cs
+++ b/Assets/Scripts/Services/Interface/IPlayerService.cs
@@ -12,6 +12,7 @@ namespace Assets.Scripts.Services.Interface
         event OnTitanDamaged OnTitanDamaged;
         event OnTitanHit OnTitanHit;
         event OnHeroHit OnHeroHit;
+        event OnHeroKill OnHeroKill;
 
         /// <summary>
         /// Triggers when damaging a <see cref="TitanBase">Titan</see>.
@@ -26,9 +27,15 @@ namespace Assets.Scripts.Services.Interface
         void TitanHit(TitanHitEvent titanHitEvent);
 
         /// <summary>
+        /// Triggers when a Hero hits another <see cref="Hero"/>.
+        /// </summary>
+        /// <param name="heroKillEvent"></param>
+        void HeroHit(HeroHitEvent heroHitEvent);
+
+        /// <summary>
         /// Triggers when a Hero kills another <see cref="Hero"/>.
         /// </summary>
         /// <param name="heroKillEvent"></param>
-        void HeroHit(HeroKillEvent heroKillEvent);
+        void HeroKill(HeroKillEvent heroKillEvent);
     }
 }

--- a/Assets/Scripts/Services/PlayerService.cs
+++ b/Assets/Scripts/Services/PlayerService.cs
@@ -11,6 +11,7 @@ namespace Assets.Scripts.Services
         public event OnTitanDamaged OnTitanDamaged;
         public event OnTitanHit OnTitanHit;
         public event OnHeroHit OnHeroHit;
+        public event OnHeroKill OnHeroKill;
 
         /// <inheritdoc/>
         public void TitanDamaged(TitanDamagedEvent titanDamagedEvent)
@@ -25,9 +26,15 @@ namespace Assets.Scripts.Services
         }
 
         /// <inheritdoc/>
-        public void HeroHit(HeroKillEvent heroKillEvent)
+        public void HeroHit(HeroHitEvent heroHitEvent)
         {
-            OnHeroHit?.Invoke(heroKillEvent);
+            OnHeroHit?.Invoke(heroHitEvent);
+        }
+
+        /// <inheritdoc/>
+        public void HeroKill(HeroKillEvent heroKillEvent)
+        {
+            OnHeroKill?.Invoke(heroKillEvent);
         }
 
         public void OnRestart()


### PR DESCRIPTION
Closes #349. Fixes do the following:

**1. Kill feed info no longer shows in single player.** I noticed the OG game doesn't show kill feed info in single player, which makes sense. I wonder why it occurred in AoTTG2. Example photo of the kill feed showing in single-player to illustrate:


![image](https://user-images.githubusercontent.com/29248979/104124056-b0be4900-53a2-11eb-868d-f6234b85119c.png)

**2. The 'GUEST killed GUEST' issue is fixed.** This only occurred for titan attacks that used 'HitEntity' (I.e. the double fist combo). The 'viewID' wasn't set to -1, meaning 'hero.netDie()' uses the player's Photon Player ID instead of the titan's name for the killer's name in the kill feed. I also decided that if the titan is a player titan then viewID will not be forced to -1, so the kill feed shows the player's username instead as the killer.

**3. Deaths in the single player 'Kills/Deaths' feed is now correctly updated for all titan attacks**.

**4. Refactoring:**
- Got rid of duplicate RPCs (OnNapeHitRPC, UpdateHealthLabelRPC)

- Fixed the ambiguous 'HeroHit' event. Added a 'HeroKill' event as part of this refactor.


