### PR TITLE
#639 character preference incorrectly persisted across lobbies

### DIFF
--- a/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
+++ b/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
@@ -53,7 +53,7 @@ namespace Assets.Scripts.UI.InGame
                 text = x.Name
             });
             CharacterDropdown.AddOptions(options.ToList());
-            OnCharacterChanged(CharacterList.Characters.First(), 0);
+            OnCharacterChanged(CharacterList.Characters[CharacterDropdown.value], 0);
             MenuManager.RegisterOpened(this);
         }
         

--- a/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
+++ b/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
@@ -36,10 +36,16 @@ namespace Assets.Scripts.UI.InGame
         {
             RecreateCharacterDropdown();
             OnCharacterChanged(CharacterList.Characters.First(), 0);
-
             CharacterDropdown.onValueChanged.AddListener(x => OnCharacterChanged(CharacterList.Characters[x], 0));
         }
 
+        
+        public void OnEnable()
+        {
+            RecreateCharacterDropdown();
+            OnCharacterChanged(CharacterList.Characters[CharacterDropdown.value], 0);
+            MenuManager.RegisterOpened(this);
+        }
         public void RecreateCharacterDropdown()
         {
             CharacterDropdown.ClearOptions();
@@ -49,14 +55,7 @@ namespace Assets.Scripts.UI.InGame
             });
             CharacterDropdown.AddOptions(options.ToList());
         }
-        
-        public void OnEnable()
-        {
-            RecreateCharacterDropdown();
-            OnCharacterChanged(CharacterList.Characters[CharacterDropdown.value], 0);
-            MenuManager.RegisterOpened(this);
-        }
-        
+
         public void OnDisable()
         {
             if (Character != null)

--- a/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
+++ b/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
@@ -39,13 +39,13 @@ namespace Assets.Scripts.UI.InGame
             CharacterDropdown.onValueChanged.AddListener(x => OnCharacterChanged(CharacterList.Characters[x], 0));
         }
 
-        
         public void OnEnable()
         {
             RecreateCharacterDropdown();
             OnCharacterChanged(CharacterList.Characters[CharacterDropdown.value], 0);
             MenuManager.RegisterOpened(this);
         }
+
         public void RecreateCharacterDropdown()
         {
             CharacterDropdown.ClearOptions();

--- a/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
+++ b/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
@@ -47,6 +47,12 @@ namespace Assets.Scripts.UI.InGame
         
         public void OnEnable()
         {
+            CharacterDropdown.ClearOptions();
+            var options = CharacterList.Characters.Select(x => new TMP_Dropdown.OptionData
+            {
+                text = x.Name
+            });
+            CharacterDropdown.AddOptions(options.ToList());
             OnCharacterChanged(CharacterList.Characters.First(), 0);
             MenuManager.RegisterOpened(this);
         }

--- a/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
+++ b/Assets/Scripts/UI/InGame/SpawnMenuV2.cs
@@ -34,18 +34,13 @@ namespace Assets.Scripts.UI.InGame
 
         public void Awake()
         {
-            CharacterDropdown.ClearOptions();
-            var options = CharacterList.Characters.Select(x => new TMP_Dropdown.OptionData
-            {
-                text = x.Name
-            });
-            CharacterDropdown.AddOptions(options.ToList());
+            RecreateCharacterDropdown();
             OnCharacterChanged(CharacterList.Characters.First(), 0);
 
             CharacterDropdown.onValueChanged.AddListener(x => OnCharacterChanged(CharacterList.Characters[x], 0));
         }
-        
-        public void OnEnable()
+
+        public void RecreateCharacterDropdown()
         {
             CharacterDropdown.ClearOptions();
             var options = CharacterList.Characters.Select(x => new TMP_Dropdown.OptionData
@@ -53,6 +48,11 @@ namespace Assets.Scripts.UI.InGame
                 text = x.Name
             });
             CharacterDropdown.AddOptions(options.ToList());
+        }
+        
+        public void OnEnable()
+        {
+            RecreateCharacterDropdown();
             OnCharacterChanged(CharacterList.Characters[CharacterDropdown.value], 0);
             MenuManager.RegisterOpened(this);
         }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.5f1
-m_EditorVersionWithRevision: 2020.2.5f1 (e2c53f129de5)
+m_EditorVersion: 2020.2.7f1
+m_EditorVersionWithRevision: 2020.2.7f1 (c53830e277f1)


### PR DESCRIPTION
Closes #639 

**Notes for the reviewer:**

*Decided a better approach for now is simply making the character selection reset upon entering a lobby. Remembering preference might be a good idea, but should be an issue on it's own.
The builds have been provided to the Testing team and so far no bugs have been found.*

**Contributor guidelines:**
1. A build has been uploaded to the discord #builds channel & has been tested by the testing team
2. Assure the code is inline with the [AoTTG2 coding conventions](https://github.com/AoTTG-2/AoTTG-2/wiki/Code-&-Style-Conventions)
3. Fix any issues that the CI reports (Sonarcloud & unit tests)

After all above conditions are met, @Lithrun will review your Pull Request. Resolve any comments of the reviewer or discuss them if you disagree.
