### PR TITLE
Cname

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aottg2.net

--- a/docfx.json
+++ b/docfx.json
@@ -40,7 +40,8 @@
     "resource": [
       {
         "files": [
-          "images/**"
+          "images/**",
+          "CNAME"
         ],
         "exclude": [
           "obj/**",


### PR DESCRIPTION
Includes the CNAME within the repository, otherwise the DocFX action will exclude it again cause https://www.aottg2.net not to work