### PR TITLE
#668 vertical hook pull

### DIFF
--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -2097,7 +2097,14 @@ namespace Assets.Scripts.Characters.Humans
                 photonView.RPC(nameof(InitializeRpc), PhotonTargets.OthersBuffered, config);
             }
 
+            //float acl = to be implemented
+            Rigidbody.mass = 0.45f; /*0.5f - (acl - 100f) * 0.001f;         <- according to antigasp and Order, this is the formula for character mass
+            I was asked by antigasp to use 0.45 (corresponding to ACL 150) as a placeholder because most testers are used to playing as Levi and it'd be
+            easier for them to spot if something is wrong. Obviously this is going to have to be reworked once character-speficic stats are implemented,
+            but for now it would probably make life easier for the testers.*/
+
             EntityService.Register(this);
+            Debug.Log("Mass of character: " + Rigidbody.mass);
         }
 
         [PunRPC]

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -138,7 +138,7 @@ namespace Assets.Scripts.Characters.Humans
 
         public MeleeWeaponTrail leftweapontrail;
         public MeleeWeaponTrail rightweapontrail;
-    
+
         [Obsolete("Should be within AHSS.cs")]
         public int leftBulletLeft = 7;
         public bool leftGunHasBullet = true;
@@ -224,7 +224,7 @@ namespace Assets.Scripts.Characters.Humans
         public SmoothSyncMovement SmoothSync { get; protected set; }
 
         [SerializeField] StringVariable bombMainPath;
-        
+
         #region Unity Methods
 
         protected override void Awake()
@@ -872,13 +872,13 @@ namespace Assets.Scripts.Characters.Humans
                                 if (!checkBoxLeft.IsActive)
                                 {
                                     checkBoxLeft.IsActive = true;
-                                    
 
-                                        if (UseWeaponTrail) 
-                                        { 
+
+                                    if (UseWeaponTrail)
+                                    {
                                         rightweapontrail.enabled = true;
                                         leftweapontrail.enabled = true;
-                                        }
+                                    }
 
                                     Rigidbody.velocity = (-Vector3.up * 30f);
                                 }
@@ -943,12 +943,12 @@ namespace Assets.Scripts.Characters.Humans
                                 {
                                     checkBoxLeft.IsActive = true;
                                     slash.Play();
-                                    
-                                        if (UseWeaponTrail)
-                                        {
-                                            rightweapontrail.enabled = true;
-                                            leftweapontrail.enabled = true;
-                                        }
+
+                                    if (UseWeaponTrail)
+                                    {
+                                        rightweapontrail.enabled = true;
+                                        leftweapontrail.enabled = true;
+                                    }
                                 }
                                 if (!checkBoxRight.IsActive)
                                 {
@@ -2104,7 +2104,6 @@ namespace Assets.Scripts.Characters.Humans
             but for now it would probably make life easier for the testers.*/
 
             EntityService.Register(this);
-            Debug.Log("Mass of character: " + Rigidbody.mass);
         }
 
         [PunRPC]
@@ -2238,7 +2237,7 @@ namespace Assets.Scripts.Characters.Humans
         }
 
         #endregion
-        
+
         public void AttackAccordingToMouse()
         {
             if (Input.mousePosition.x < (Screen.width * 0.5))

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -2097,9 +2097,11 @@ namespace Assets.Scripts.Characters.Humans
                 photonView.RPC(nameof(InitializeRpc), PhotonTargets.OthersBuffered, config);
             }
 
-            //float acl = to be implemented
-            Rigidbody.mass = 0.45f; /*0.5f - (acl - 100f) * 0.001f;         <- according to antigasp and Order, this is the formula for character mass
-            I was asked by antigasp to use 0.45 (corresponding to ACL 150) as a placeholder because most testers are used to playing as Levi and it'd be
+            /*int index = EquipmentType == EquipmentType.Ahss ? 1 : 0;              
+            float acl = preset.CharacterBuild[index].Stats.Acceleration;
+            Rigidbody.mass = 0.5f - (acl - 100f) * 0.001f;*/      //<-once correct character presets are implemented, uncomment these value assignation
+            Rigidbody.mass = 0.45f;                               //and delete this one
+            /*I was asked by antigasp to use 0.45 (corresponding to ACL 150) as a placeholder because most testers are used to playing as Levi and it'd be
             easier for them to spot if something is wrong. Obviously this is going to have to be reworked once character-speficic stats are implemented,
             but for now it would probably make life easier for the testers.*/
 


### PR DESCRIPTION
Closes #668 

**Notes for the reviewer:**

I confirmed together with antigasp that the entire issue was incorrect character mass values. 
For now, I set the mass of the character to be 0.45, which is equivalent to Levi's mass with his 150 ACL stat. *This is only a temporary fix so testers can work with the ODM better.* Once the character-specific stats are implemented, the mass calculation will need to be adjusted. 

**Contributor guidelines:**
1. A build has been uploaded to the discord #builds channel & has been tested by the testing team
2. Assure the code is inline with the [AoTTG2 coding conventions](https://github.com/AoTTG-2/AoTTG-2/wiki/Code-&-Style-Conventions)
3. Fix any issues that the CI reports (Sonarcloud & unit tests)

After all above conditions are met, @Lithrun will review your Pull Request. Resolve any comments of the reviewer or discuss them if you disagree.
