### PR TITLE
added timer between gasbursts

### DIFF
--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -208,6 +208,8 @@ namespace Assets.Scripts.Characters.Humans
         private float wallRunTime { get; set; }
 
         private readonly System.Diagnostics.Stopwatch burstCD = new System.Diagnostics.Stopwatch();
+        private const int BurstCDmin = 1;
+        private const int BurstCDmax = 300;
 
         public bool IsGrabbed => state == HumanState.Grab;
         public bool IsInvincible => (invincible > 0f);
@@ -2661,7 +2663,7 @@ namespace Assets.Scripts.Characters.Humans
 
         private void Dash(float horizontal, float vertical)
         {
-            if (((dashTime <= 0f) && (currentGas > 0f)) && !isMounted && (burstCD.ElapsedMilliseconds <=1 || burstCD.ElapsedMilliseconds >=300))
+            if (((dashTime <= 0f) && (currentGas > 0f)) && !isMounted && (burstCD.ElapsedMilliseconds <= BurstCDmin || burstCD.ElapsedMilliseconds >= BurstCDmax))
             {
                 burstCD.Reset();
                 UseGas(totalGas * 0.04f);

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -207,6 +207,8 @@ namespace Assets.Scripts.Characters.Humans
         private bool wallJump { get; set; }
         private float wallRunTime { get; set; }
 
+        private System.Diagnostics.Stopwatch burstCD = new System.Diagnostics.Stopwatch();
+
         public bool IsGrabbed => state == HumanState.Grab;
         public bool IsInvincible => (invincible > 0f);
 
@@ -2659,8 +2661,9 @@ namespace Assets.Scripts.Characters.Humans
 
         private void Dash(float horizontal, float vertical)
         {
-            if (((dashTime <= 0f) && (currentGas > 0f)) && !isMounted)
+            if (((dashTime <= 0f) && (currentGas > 0f)) && !isMounted && (burstCD.ElapsedMilliseconds <=1 || burstCD.ElapsedMilliseconds >=300))
             {
+                burstCD.Reset();
                 UseGas(totalGas * 0.04f);
                 facingDirection = GetGlobalFacingDirection(horizontal, vertical);
                 dashV = GetGlobaleFacingVector3(facingDirection);
@@ -2675,6 +2678,7 @@ namespace Assets.Scripts.Characters.Humans
                 state = HumanState.AirDodge;
                 FalseAttack();
                 Rigidbody.AddForce((dashV * 40f), ForceMode.VelocityChange);
+                burstCD.Start();
             }
         }
 

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -207,7 +207,7 @@ namespace Assets.Scripts.Characters.Humans
         private bool wallJump { get; set; }
         private float wallRunTime { get; set; }
 
-        private System.Diagnostics.Stopwatch burstCD = new System.Diagnostics.Stopwatch();
+        private readonly System.Diagnostics.Stopwatch burstCD = new System.Diagnostics.Stopwatch();
 
         public bool IsGrabbed => state == HumanState.Grab;
         public bool IsInvincible => (invincible > 0f);


### PR DESCRIPTION
Closes #263 

**Notes for the reviewer:**
Added a little timer between gasburst so it doesn't happen twice and you just lose extra gas and don't gain more speed from it
*(Add information which you think is important for the reviewer to be aware of (i.e. functionality X is not included as this was too complex, see issue 123))*

**Contributor guidelines:**
1. A build has been uploaded to the discord #builds channel & has been tested by the testing team
2. Assure the code is inline with the [AoTTG2 coding conventions](https://github.com/AoTTG-2/AoTTG-2/wiki/Code-&-Style-Conventions)
3. Fix any issues that the CI reports (Sonarcloud & unit tests)

After all above conditions are met, @Lithrun will review your Pull Request. Resolve any comments of the reviewer or discuss them if you disagree.
