### PR TITLE
Fixed Wave Mode Spawning

### DIFF
--- a/Assets/Scripts/Gamemode/WaveGamemode.cs
+++ b/Assets/Scripts/Gamemode/WaveGamemode.cs
@@ -80,14 +80,11 @@ namespace Assets.Scripts.Gamemode
             {
                 if (Wave % Settings.BossWave.Value == 0)
                 {
-                    for (var i = 0; i < Wave / Settings.BossWave.Value; i++)
-                    {
-                        SpawnService.Spawn<MindlessTitan>(GetWaveTitanConfiguration(Settings.BossType.Value));
-                    }
+                    StartCoroutine(SpawnBossTitan(Wave / Settings.BossWave.Value));
                 }
                 else
                 {
-                    StartCoroutine(SpawnTitan(GameSettings.Titan.Start.Value + Wave * Settings.WaveIncrement.Value));
+                    StartCoroutine(SpawnTitan(GameSettings.Titan.Start.Value + (Wave - 1) * Settings.WaveIncrement.Value));
                 }
             }
         }
@@ -136,6 +133,18 @@ namespace Assets.Scripts.Gamemode
                 var randomSpawn = GetSpawnLocation();
                 SpawnService.Spawn<MindlessTitan>(randomSpawn.position, randomSpawn.rotation,
                     GetWaveTitanConfiguration());
+                yield return new WaitForEndOfFrame();
+            }
+        }
+
+        private IEnumerator SpawnBossTitan(int titans)
+        {
+            for (var i = 0; i < titans; i++)
+            {
+                if (EntityService.Count<MindlessTitan>() >= GameSettings.Titan.Limit.Value) break;
+                var randomSpawn = GetSpawnLocation();
+                SpawnService.Spawn<MindlessTitan>(randomSpawn.position, randomSpawn.rotation,
+                    GetWaveTitanConfiguration(Settings.BossType.Value));
                 yield return new WaitForEndOfFrame();
             }
         }

--- a/Assets/Scripts/Settings/Gamemodes/WaveGamemodeSettings.cs
+++ b/Assets/Scripts/Settings/Gamemodes/WaveGamemodeSettings.cs
@@ -20,7 +20,7 @@ namespace Assets.Scripts.Settings.Gamemodes
             Respawn.Mode = RespawnMode.NewRound;
             StartWave = 1;
             MaxWave = 20;
-            WaveIncrement = 2;
+            WaveIncrement = 1;
             BossWave = 5;
             BossType = MindlessTitanType.Punk;
 


### PR DESCRIPTION
Changed number of titan per wave from (Initial number + Wave * Increment) to (Initial number + (Wave - 1) * Increment)
The Boss Titan should now be spawned once the boss wave is reached.

Closes #623

**Contributor guidelines:**
1. A build has been uploaded to the discord #builds channel & has been tested by the testing team
2. Assure the code is inline with the [AoTTG2 coding conventions](https://github.com/AoTTG-2/AoTTG-2/wiki/Code-&-Style-Conventions)
3. Fix any issues that the CI reports (Sonarcloud & unit tests)

After all above conditions are met, @Lithrun will review your Pull Request. Resolve any comments of the reviewer or discuss them if you disagree.
