### PR TITLE
Disabled horses in the GamemodeSettings constructor

### DIFF
--- a/Assets/Scripts/Settings/Gamemodes/GamemodeSettings.cs
+++ b/Assets/Scripts/Settings/Gamemodes/GamemodeSettings.cs
@@ -66,6 +66,7 @@ namespace Assets.Scripts.Settings.Gamemodes
                 Mindless = new MindlessTitanSettings()
             };
             Horse = new HorseSettings();
+            Horse.Enabled = false;
             Respawn = new RespawnSettings();
             Time = new TimeSettings();
             TeamMode = TeamMode.Disabled;


### PR DESCRIPTION
Closes #512

I apologize that it took me so long to create a pull request. I got pog reacts to my uploaded build, but I didn't interpret that as confirmation that it works. Future builds from others have only been reacted to, so I assume that's the way it is. 

I disabled horses in the GamemodeSettings constructor because once the horses were set to enabled, they remained enabled no matter which map the player went to.