### PR TITLE
#765 crosshair adjustment

### DIFF
--- a/Assets/Resources/Character2/HumanBase2.prefab
+++ b/Assets/Resources/Character2/HumanBase2.prefab
@@ -17148,7 +17148,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4759155575018946212}
   m_LocalRotation: {x: 0.06328958, y: 0.06328935, z: 0.70426875, w: 0.70426875}
-  m_LocalPosition: {x: 0.001046091, y: -0.001890445, z: 0.001161152}
+  m_LocalPosition: {x: 0.001020005, y: -0.001890445, z: 0.001175438}
   m_LocalScale: {x: 0.009405191, y: 0.009405194, z: 0.009405193}
   m_Children: []
   m_Father: {fileID: 4755987445250634402}

--- a/Assets/Scripts/Characters/Humans/Bullet.cs
+++ b/Assets/Scripts/Characters/Humans/Bullet.cs
@@ -1,3 +1,4 @@
+using System;
 using Assets.Scripts.Characters.Titan;
 using System.Collections;
 using UnityEngine;
@@ -63,7 +64,7 @@ namespace Assets.Scripts.Characters.Humans
         {
             this.phase = 2;
             this.killTime = 0f;
-            object[] parameters = { 2 };
+            object[] parameters = {2};
             base.photonView.RPC(nameof(setPhase), PhotonTargets.Others, parameters);
         }
 
@@ -214,75 +215,46 @@ namespace Assets.Scripts.Characters.Humans
             UnityEngine.Object.Destroy(this.rope);
             UnityEngine.Object.Destroy(base.gameObject);
         }
-
-        public void launch(Vector3 v, Vector3 v2, string launcher_ref, bool isLeft, GameObject hero, bool leviMode = false)
+        
+        public void Launch(Source source, GameObject hookRef, Vector3 v, Vector3 v2, Hero hero, bool leviMode = false)
         {
-            if (this.phase != 2)
+            if (phase == 2) return;
+            
+            master = hero.gameObject;
+            velocity = v;
+            var f = Mathf.Acos(Vector3.Dot(v.normalized, v2.normalized)) * Mathf.Rad2Deg;
+            velocity2 = Mathf.Abs(f) > 90f ? Vector3.zero : Vector3.Project(v2, v);
+
+            myRef = hookRef;
+
+            nodes = new ArrayList {myRef.transform.position};
+            phase = 0;
+            this.leviMode = leviMode;
+            left = IsLeft(source);
+            if (photonView.isMine)
             {
-                this.master = hero;
-                this.velocity = v;
-                float f = Mathf.Acos(Vector3.Dot(v.normalized, v2.normalized)) * Mathf.Rad2Deg;
-                if (Mathf.Abs(f) > 90f)
-                {
-                    this.velocity2 = Vector3.zero;
-                }
-                else
-                {
-                    this.velocity2 = Vector3.Project(v2, v);
-                }
-                if (launcher_ref == "hookRefL1")
-                {
-                    this.myRef = hero.GetComponent<Hero>().hookRefL1;
-                }
-                if (launcher_ref == "hookRefL2")
-                {
-                    this.myRef = hero.GetComponent<Hero>().hookRefL2;
-                }
-                if (launcher_ref == "hookRefR1")
-                {
-                    this.myRef = hero.GetComponent<Hero>().hookRefR1;
-                }
-                if (launcher_ref == "hookRefR2")
-                {
-                    this.myRef = hero.GetComponent<Hero>().hookRefR2;
-                }
-                this.nodes = new ArrayList();
-                this.nodes.Add(this.myRef.transform.position);
-                this.phase = 0;
-                this.leviMode = leviMode;
-                this.left = isLeft;
-                if (base.photonView.isMine)
-                {
-                    object[] parameters = new object[] { hero.GetComponent<Hero>().photonView.viewID, launcher_ref };
-                    base.photonView.RPC(nameof(myMasterIs), PhotonTargets.Others, parameters);
-                    object[] objArray2 = new object[] { v, this.velocity2, this.left };
-                    base.photonView.RPC(nameof(setVelocityAndLeft), PhotonTargets.Others, objArray2);
-                }
-                base.transform.position = this.myRef.transform.position;
-                base.transform.rotation = Quaternion.LookRotation(v.normalized);
+                var parameters = new object[] {hero.photonView.viewID, source};
+                photonView.RPC(nameof(myMasterIs), PhotonTargets.Others, parameters);
+                var objArray2 = new object[] {v, velocity2, left};
+                photonView.RPC(nameof(setVelocityAndLeft), PhotonTargets.Others, objArray2);
             }
+
+            transform.SetPositionAndRotation(myRef.transform.position, Quaternion.LookRotation(v.normalized));
         }
 
         [PunRPC]
-        private void myMasterIs(int id, string launcherRef)
+        private void myMasterIs(int id, Source source)
         {
-            this.master = PhotonView.Find(id).gameObject;
-            if (launcherRef == "hookRefL1")
+            master = PhotonView.Find(id).gameObject;
+            var hero = master.GetComponent<Hero>();
+            myRef = source switch
             {
-                this.myRef = this.master.GetComponent<Hero>().hookRefL1;
-            }
-            if (launcherRef == "hookRefL2")
-            {
-                this.myRef = this.master.GetComponent<Hero>().hookRefL2;
-            }
-            if (launcherRef == "hookRefR1")
-            {
-                this.myRef = this.master.GetComponent<Hero>().hookRefR1;
-            }
-            if (launcherRef == "hookRefR2")
-            {
-                this.myRef = this.master.GetComponent<Hero>().hookRefR2;
-            }
+                Source.BeltLeft => hero.hookRefL1,
+                Source.BeltRight => hero.hookRefR1,
+                Source.GunLeft => hero.hookRefL2,
+                Source.GunRight => hero.hookRefR2,
+                _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
+            };
         }
 
         [PunRPC]
@@ -416,6 +388,7 @@ namespace Assets.Scripts.Characters.Humans
                         base.gameObject.GetComponent<MeshRenderer>().enabled = false;
                     }
                 }
+
                 if (this.phase == 0)
                 {
                     this.setLinePhase0();
@@ -470,7 +443,9 @@ namespace Assets.Scripts.Characters.Humans
                             {
                                 Vector3 position = ((Vector3) this.spiralNodes[i]) + vector4;
                                 float num11 = (this.spiralNodes.Count - 1) - (this.spiralcount * 0.5f);
-                                position = new Vector3(position.x, (position.y * ((num11 - i) / num11)) + (base.gameObject.transform.position.y * (i / num11)), position.z);
+                                position = new Vector3(position.x,
+                                    (position.y * ((num11 - i) / num11)) +
+                                    (base.gameObject.transform.position.y * (i / num11)), position.z);
                                 this.lineRenderer.SetPosition(i, position);
                             }
                             else
@@ -504,6 +479,23 @@ namespace Assets.Scripts.Characters.Humans
                 }
             }
         }
+
+        public static bool IsLeft(Source source) =>
+            source switch
+            {
+                Source.BeltLeft => true,
+                Source.GunLeft => true,
+                Source.BeltRight => false,
+                Source.GunRight => false,
+                _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
+            };
+
+        public enum Source
+        {
+            BeltLeft,
+            BeltRight,
+            GunLeft,
+            GunRight
+        }
     }
 }
-

--- a/Assets/Scripts/Characters/Humans/Bullet.cs
+++ b/Assets/Scripts/Characters/Humans/Bullet.cs
@@ -216,7 +216,7 @@ namespace Assets.Scripts.Characters.Humans
             UnityEngine.Object.Destroy(base.gameObject);
         }
         
-        public void Launch(Source source, GameObject hookRef, Vector3 v, Vector3 v2, Hero hero, bool leviMode = false)
+        public void Launch(HookSource source, GameObject hookRef, Vector3 v, Vector3 v2, Hero hero, bool leviMode = false)
         {
             if (phase == 2) return;
             
@@ -243,16 +243,16 @@ namespace Assets.Scripts.Characters.Humans
         }
 
         [PunRPC]
-        private void myMasterIs(int id, Source source)
+        private void myMasterIs(int id, HookSource source)
         {
             master = PhotonView.Find(id).gameObject;
             var hero = master.GetComponent<Hero>();
             myRef = source switch
             {
-                Source.BeltLeft => hero.hookRefL1,
-                Source.BeltRight => hero.hookRefR1,
-                Source.GunLeft => hero.hookRefL2,
-                Source.GunRight => hero.hookRefR2,
+                HookSource.BeltLeft => hero.hookRefL1,
+                HookSource.BeltRight => hero.hookRefR1,
+                HookSource.GunLeft => hero.hookRefL2,
+                HookSource.GunRight => hero.hookRefR2,
                 _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
             };
         }
@@ -480,17 +480,17 @@ namespace Assets.Scripts.Characters.Humans
             }
         }
 
-        public static bool IsLeft(Source source) =>
+        public static bool IsLeft(HookSource source) =>
             source switch
             {
-                Source.BeltLeft => true,
-                Source.GunLeft => true,
-                Source.BeltRight => false,
-                Source.GunRight => false,
+                HookSource.BeltLeft => true,
+                HookSource.GunLeft => true,
+                HookSource.BeltRight => false,
+                HookSource.GunRight => false,
                 _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
             };
 
-        public enum Source
+        public enum HookSource
         {
             BeltLeft,
             BeltRight,

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -240,9 +240,6 @@ namespace Assets.Scripts.Characters.Humans
         public Rigidbody Rigidbody { get; protected set; }
         public SmoothSyncMovement SmoothSync { get; protected set; }
 
-        private Bullet.Source LeftSource => useGun ? Bullet.Source.GunLeft : Bullet.Source.BeltLeft;
-        private Bullet.Source RightSource => useGun ? Bullet.Source.GunRight : Bullet.Source.BeltRight;
-        
         [SerializeField] StringVariable bombMainPath;
 
         #region Unity Methods
@@ -3203,17 +3200,17 @@ namespace Assets.Scripts.Characters.Humans
             sparks_em.enabled = false;
         }
 
-        public void LaunchRope(Bullet.Source source, float distance, Vector3 point, bool single, bool leviMode = false)
+        public void LaunchRope(Bullet.HookSource source, float distance, Vector3 point, bool single, bool leviMode = false)
         {
             if (currentGas <= 0f) return;
             UseGas();
 
             var hookRef = source switch
             {
-                Bullet.Source.BeltLeft => hookRefL1,
-                Bullet.Source.BeltRight => hookRefR1,
-                Bullet.Source.GunLeft => hookRefL2,
-                Bullet.Source.GunRight => hookRefR2,
+                Bullet.HookSource.BeltLeft => hookRefL1,
+                Bullet.HookSource.BeltRight => hookRefR1,
+                Bullet.HookSource.GunLeft => hookRefL2,
+                Bullet.HookSource.GunRight => hookRefR2,
                 _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
             };
 
@@ -3243,12 +3240,18 @@ namespace Assets.Scripts.Characters.Humans
             }
         }
         
-        public void LaunchLeftRope(float distance, Vector3 point, bool single, bool leviMode = false) =>
-            LaunchRope(LeftSource, distance, point, single, leviMode);
+        public void LaunchLeftRope(float distance, Vector3 point, bool single, bool leviMode = false)
+        {
+            var source = useGun ? Bullet.HookSource.GunLeft : Bullet.HookSource.BeltLeft;
+            LaunchRope(source, distance, point, single, leviMode);
+        }
 
-        public void LaunchRightRope(float distance, Vector3 point, bool single, bool leviMode = false) =>
-            LaunchRope(RightSource, distance, point, single, leviMode);
-        
+        public void LaunchRightRope(float distance, Vector3 point, bool single, bool leviMode = false)
+        {
+            var source = useGun ? Bullet.HookSource.GunRight : Bullet.HookSource.BeltRight;
+            LaunchRope(source, distance, point, single, leviMode);
+        }
+
         private void LeftArmAimTo(Vector3 target)
         {
             float y = target.x - upperarmL.transform.position.x;

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -3220,24 +3220,25 @@ namespace Assets.Scripts.Characters.Humans
             var startPos = transform.position;
             var startRot = transform.rotation;
             var hook = PhotonNetwork.Instantiate("hook", startPos, startRot, 0).GetComponent<Bullet>();
+
+            var multiOffset = transform.right * (distance <= 50f ? distance * 0.05f : distance * 0.3f);
             if (Bullet.IsLeft(source))
             {
                 hookLeft = hook;
-                LaunchHook(hook);
+                LaunchHook(hook, !single ? -multiOffset : Vector3.zero);
                 launchPointLeft = Vector3.zero;
             }
             else
             {
                 hookRight = hook;
-                LaunchHook(hook);
+                LaunchHook(hook, !single ? multiOffset : Vector3.zero);
                 launchPointRight = Vector3.zero;
             }
 
-            void LaunchHook(Bullet hook)
+            void LaunchHook(Bullet hook, Vector3 offset)
             {
-                var num = !single ? distance <= 50f ? distance * 0.05f : distance * 0.3f : 0f;
                 var hookPos = hook.transform.position = hookRef.transform.position;
-                var vector = Vector3.Normalize(point - transform.right * num - hookPos) * 3f;
+                var vector = Vector3.Normalize(point - hookPos + offset) * 3f;
                 hook.Launch(source, hookRef, vector, Rigidbody.velocity, this, leviMode);
             }
         }

--- a/Assets/Scripts/Characters/Humans/Hero.cs
+++ b/Assets/Scripts/Characters/Humans/Hero.cs
@@ -3238,8 +3238,6 @@ namespace Assets.Scripts.Characters.Humans
                 var num = !single ? distance <= 50f ? distance * 0.05f : distance * 0.3f : 0f;
                 var hookPos = hook.transform.position = hookRef.transform.position;
                 var vector = Vector3.Normalize(point - transform.right * num - hookPos) * 3f;
-                Debug.DrawLine(hookPos + Vector3.up * 0.01f, point + Vector3.up * 0.01f, Color.green, 10f);
-                Debug.DrawLine(hookPos, hookPos + vector.normalized * distance, Color.magenta, 10f);
                 hook.Launch(source, hookRef, vector, Rigidbody.velocity, this, leviMode);
             }
         }

--- a/Assets/Scripts/Characters/Humans/Hero.cs.meta
+++ b/Assets/Scripts/Characters/Humans/Hero.cs.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: c2ade5059944e77468ce66f0f1fb36c9
-timeCreated: 1582403864
-licenseType: Free
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 5
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Characters/Humans/Skills/LeviSkill.cs
+++ b/Assets/Scripts/Characters/Humans/Skills/LeviSkill.cs
@@ -32,7 +32,7 @@ namespace Assets.Scripts.Characters.Humans.Skills
                     Hero.ReleaseIfIHookSb();
                 }
                 Hero.dashDirection = hit.point - Hero.transform.position;
-                Hero.LaunchRightRope(hit.distance, hit.point, true, 1);
+                Hero.LaunchRightRope(hit.distance, hit.point, true, true);
                 Hero.rope.Play();
             }
             Hero.facingDirection = Mathf.Atan2(Hero.dashDirection.x, Hero.dashDirection.z) * Mathf.Rad2Deg;


### PR DESCRIPTION
Closes #765

**Notes for the reviewer:**
I have made two changes:
- The left hook should now be at the same exact height as the right hook.
- Both hooks should land exactly where the cursor is pointing (in TPS, of course). Previously, hooks would land ~1.4 units above their intended target.

**Contributor guidelines:**
- [x] A build has been uploaded to the discord #builds channel
- [x] The build has been tested by the testing team
- [x] Assure the code is inline with the [AoTTG2 coding conventions](https://github.com/AoTTG-2/AoTTG-2/wiki/Code-&-Style-Conventions)
- [x] Fix any issues that the CI reports (Sonarcloud & unit tests)